### PR TITLE
Use monads for refinement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .run
 out
 *.iml
+wiki

--- a/main/src/io/github/iltotore/iron/constraint/IllegalValueError.scala
+++ b/main/src/io/github/iltotore/iron/constraint/IllegalValueError.scala
@@ -1,0 +1,9 @@
+package io.github.iltotore.iron.constraint
+
+/**
+ * Represents a type-level assertion failure.
+ * @param input the invalid value
+ * @param constraint the type constraint applied to [[input]]
+ * @tparam A the input type
+ */
+case class IllegalValueError[A](input: A, constraint: Constraint[A, _]) extends Error

--- a/main/src/io/github/iltotore/iron/constraint/package.scala
+++ b/main/src/io/github/iltotore/iron/constraint/package.scala
@@ -1,7 +1,6 @@
 package io.github.iltotore.iron
 
-import io.github.iltotore.iron._
-import scala.compiletime._
+import io.github.iltotore.iron.{Constrained, compileTime}
 import scala.language.implicitConversions
 import math.Ordering.Implicits.infixOrderingOps
 
@@ -9,23 +8,17 @@ package object constraint {
 
   /**
    * Implicit assertion check
-   * @param value the value passed to the assertion
+   *
+   * @param value      the value passed to the assertion
    * @param constraint the applied type constraint
    * @tparam A the input type
    * @tparam B the constraint's dummy
    * @return the value as Constrained (meaning "asserted value")
+   * @note Due to a type inference bug of Scala 3, [[constrainedToValue]] was moved to the package object.
    */
   implicit inline def valueToConstrained[A, B](value: A)(using inline constraint: Constraint[A, B]): Constrained[A, B] = {
-    compileTime.preAssert(constraint.assert(value))
-    Constrained(value)
+    Constrained(compileTime.preAssert(value, constraint))
   }
 
-  /**
-   * Implicit conversion from Constrained[A, B] to its shadowed type
-   * @param constrained the Constrained to be cast from
-   * @tparam A the input type
-   * @tparam B the constraint's dummy
-   * @return constrained as A
-   */
-  implicit inline def constrainedToValue[A, B](constrained: Constrained[A, B]): A = constrained
+  //Due to a Dotty type inference bug,
 }

--- a/main/src/io/github/iltotore/iron/package.scala
+++ b/main/src/io/github/iltotore/iron/package.scala
@@ -1,18 +1,26 @@
 package io.github.iltotore
 
-import io.github.iltotore.iron.constraint.Constraint
+import io.github.iltotore.iron.constraint.{Constraint, IllegalValueError}
 
 import scala.compiletime.constValue
+import scala.language.implicitConversions
 
 
 package object iron {
 
   /**
-   * An opaque alias of A marked as "checked".
+   * Alias for Either[IllegalValueError[A], A], used as constraint result.
+   * @tparam A the input type
+   */
+  type Refined[A] = Either[IllegalValueError[A], A]
+
+
+  /**
+   * An alias of Refined marked as "checked".
    * @tparam A the input/raw type
    * @tparam B the passed constraint's dummy
    */
-  opaque type Constrained[A, B] <: A = A
+  opaque type Constrained[A, B] = Refined[A]
   type ==>[A, B] = Constrained[A, B]
 
   object Constrained {
@@ -24,6 +32,15 @@ package object iron {
      * @tparam B the passed constraint's dummy
      * @return The [[Constrained]] version of [[value]]
      */
-    def apply[A, B](value: A): Constrained[A, B] = value
+    def apply[A, B](value: Refined[A]): Constrained[A, B] = value
   }
+
+  /**
+   * Implicit conversion from Constrained[A, B] to its shadowed type
+   * @param constrained the Constrained to be cast from
+   * @tparam A the input type
+   * @tparam B the constraint's dummy
+   * @return the Constrained as Refined[A]
+   */
+  implicit def constrainedToValue[A, B](constrained: Constrained[A, B]): Refined[A] = constrained
 }


### PR DESCRIPTION
Fixes #2

Refined parameters now returns an instance of `Refined[A]` (alias for `Either[IllegalValueError[A], A]`).