### PR TITLE
Add boolean-like operations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,4 +26,4 @@ jobs:
       - uses: actions/checkout@v2
           
       - name: Build project
-        run: chmod u+rx mill && ./mill -i __.compile
+        run: chmod u+rx mill && ./mill -i -D iron.fallback=allow __.compile

--- a/main/src/io/github/iltotore/iron/constraint/package.scala
+++ b/main/src/io/github/iltotore/iron/constraint/package.scala
@@ -55,7 +55,7 @@ package object constraint {
   /**
    * Constraint: checks if the input value doesn't pass B's constraint.
    *
-   * @tparam B the reversed constraint's dummy.
+   * @tparam B the reversed constraint's dummy
    */
   trait Not[B]
 
@@ -69,4 +69,20 @@ package object constraint {
   inline given[A, B, C <: Constraint[A, B]](using C): NotConstraint[A, B, C] = new NotConstraint
 
 
+  /**
+   * Constraint: checks if the value pass B or C. Acts like a boolean OR.
+   *
+   * @tparam B the first constraint's dummy
+   * @tparam C the second constraint's dummy
+   */
+  trait Or[B, C]
+
+  type ||[B, C] = Or[B, C]
+
+  class OrConstraint[A, B, C, CB <: Constraint[A, B], CC <: Constraint[A, C]](using left: CB, right: CC) extends Constraint[A, Or[B, C]] {
+
+    override inline def assert(value: A): Boolean = left.assert(value) || right.assert(value)
+  }
+
+  inline given[A, B, C, CB <: Constraint[A, B], CC <: Constraint[A, C]](using CB, CC): OrConstraint[A, B, C, CB, CC] = new OrConstraint
 }

--- a/main/src/io/github/iltotore/iron/constraint/package.scala
+++ b/main/src/io/github/iltotore/iron/constraint/package.scala
@@ -85,4 +85,22 @@ package object constraint {
   }
 
   inline given[A, B, C, CB <: Constraint[A, B], CC <: Constraint[A, C]](using CB, CC): OrConstraint[A, B, C, CB, CC] = new OrConstraint
+
+
+  /**
+   * Constraint: checks if the value pass both B and C. Acts like a boolean AND.
+   *
+   * @tparam B the first constraint's dummy
+   * @tparam C the second constraint's dummy
+   */
+  trait And[B, C]
+
+  type &&[B, C] = And[B, C]
+
+  class AndConstraint[A, B, C, CB <: Constraint[A, B], CC <: Constraint[A, C]](using left: CB, right: CC) extends Constraint[A, And[B, C]] {
+
+    override inline def assert(value: A): Boolean = left.assert(value) && right.assert(value)
+  }
+
+  inline given[A, B, C, CB <: Constraint[A, B], CC <: Constraint[A, C]](using CB, CC): AndConstraint[A, B, C, CB, CC] = new AndConstraint
 }

--- a/main/src/io/github/iltotore/iron/constraint/package.scala
+++ b/main/src/io/github/iltotore/iron/constraint/package.scala
@@ -55,36 +55,18 @@ package object constraint {
   /**
    * Constraint: checks if the input value doesn't pass B's constraint.
    *
-   * @tparam B the "inverted" constraint's dummy.
-   * @note use the [[Not]] alias instead of [[NotDummy]] directly: {{{
-   *          //Bad
-   *          def inverse(x: Double ==> NotDummy[StrictEqual[0]]): Double = 1/x
-   *
-   *          //Good
-   *          def inverse(x: Double ==> Not[StrictEqual[0]]): Double = 1/x
-   *
-   *          //Even better
-   *          def inverse(x: Double ==> Not[0]): Double = 1/x
-   * }}}
+   * @tparam B the reversed constraint's dummy.
    */
-  trait NotDummy[B]
+  trait Not[B]
 
-  /**
-   * Proxy for NotDummy[B] if B has a constraint. Not[StrictEqual[B]] otherwise.
-   *
-   * @tparam B the constraint's dummy or the value used for StrictEqual[B]
-   */
-  type Not[B] = B match {
+  type \[A, V] = A ==> Not[StrictEqual[V]]
 
-    case Constraint[_, _] => NotDummy[B]
-
-    case _ => NotDummy[StrictEqual[B]]
-  }
-
-  class NotConstraint[A, B, C <: Constraint[A, B]](using constraint: C) extends Constraint[A, NotDummy[B]] {
+  class NotConstraint[A, B, C <: Constraint[A, B]](using constraint: C) extends Constraint[A, Not[B]] {
 
     override inline def assert(value: A): Boolean = !constraint.assert(value)
   }
 
   inline given[A, B, C <: Constraint[A, B]](using C): NotConstraint[A, B, C] = new NotConstraint
+
+
 }

--- a/main/test/src/io/github/iltotore/iron/test/CompileTimeSpec.scala
+++ b/main/test/src/io/github/iltotore/iron/test/CompileTimeSpec.scala
@@ -2,17 +2,17 @@ package io.github.iltotore.iron.test
 
 import org.scalatest._
 import flatspec._
-import io.github.iltotore.iron._, constraint._
+import io.github.iltotore.iron._, constraint.{_, given}
 import matchers._
 
-class ConstraintSpec extends UnitSpec {
+class CompileTimeSpec extends UnitSpec {
 
   "A compile-time constraint" should "compile if assertion is passed" in {
     "valueToConstrained[Boolean, Dummy](true)" should compile
     "valueToConstrained[Boolean, Dummy](false)" shouldNot compile
   }
 
-  "An Equal[V] constraint" should "compile if the argument == V" in {
+  "A StrictEqual[V] constraint" should "compile if the argument == V" in {
 
     def dummy(x: Int == 0): Unit = {}
 

--- a/main/test/src/io/github/iltotore/iron/test/CompileTimeSpec.scala
+++ b/main/test/src/io/github/iltotore/iron/test/CompileTimeSpec.scala
@@ -1,9 +1,7 @@
 package io.github.iltotore.iron.test
 
-import org.scalatest._
-import flatspec._
+import org.scalatest._, flatspec._, matchers._
 import io.github.iltotore.iron._, constraint.{_, given}
-import matchers._
 
 class CompileTimeSpec extends UnitSpec {
 

--- a/main/test/src/io/github/iltotore/iron/test/RuntimeSpec.scala
+++ b/main/test/src/io/github/iltotore/iron/test/RuntimeSpec.scala
@@ -13,11 +13,20 @@ class RuntimeSpec extends UnitSpec {
     assert(dummy(1).isLeft)
   }
 
-  "A Not[B] constraint" should "return Right if the argument doesn't pass " in {
+  "A Not[B] constraint" should "return Right if the argument doesn't pass the reversed constraint" in {
 
     def dummy(x: Int \ 0): Int \ 0 = x
 
     assert(dummy(0).isLeft)
     assert(dummy(1).isRight)
+  }
+
+  "An Or[B, C] constraint" should "return Right if the argument satisfies one of the two passed assertions" in {
+
+    def dummy(x: Int ==> (Equal[0] || Equal[1])): Int ==> (Equal[0] || Equal[1]) = x
+
+    assert(dummy(0).isRight)
+    assert(dummy(1).isRight)
+    assert(dummy(2).isLeft)
   }
 }

--- a/main/test/src/io/github/iltotore/iron/test/RuntimeSpec.scala
+++ b/main/test/src/io/github/iltotore/iron/test/RuntimeSpec.scala
@@ -29,4 +29,13 @@ class RuntimeSpec extends UnitSpec {
     assert(dummy(1).isRight)
     assert(dummy(2).isLeft)
   }
+
+  "An And[B, C] constraint" should "return Right if the argument satisfies both B and C" in {
+
+    def dummy(x: Int ==> (Positive && Even)): Int ==> (Positive && Even) = x
+
+    assert(dummy(2).isRight)
+    assert(dummy(3).isLeft)
+    assert(dummy(-2).isLeft)
+  }
 }

--- a/main/test/src/io/github/iltotore/iron/test/RuntimeSpec.scala
+++ b/main/test/src/io/github/iltotore/iron/test/RuntimeSpec.scala
@@ -1,0 +1,15 @@
+package io.github.iltotore.iron.test
+
+import org.scalatest._, flatspec._, matchers._
+import io.github.iltotore.iron._, constraint.{_, given}
+
+class RuntimeSpec extends UnitSpec {
+
+  "An Equal[V] constraint" should "return Right if the argument equals to V" in {
+
+    def dummy(x: Int ==> Equal[0]): Int ==> Equal[0] = x
+
+    assert(dummy(0).isRight)
+    assert(dummy(1).isLeft)
+  }
+}

--- a/main/test/src/io/github/iltotore/iron/test/RuntimeSpec.scala
+++ b/main/test/src/io/github/iltotore/iron/test/RuntimeSpec.scala
@@ -15,9 +15,9 @@ class RuntimeSpec extends UnitSpec {
 
   "A Not[B] constraint" should "return Right if the argument doesn't pass " in {
 
-    def dummy(x: Int ==> Equal[0]): Int ==> Equal[0] = x
+    def dummy(x: Int \ 0): Int \ 0 = x
 
-    assert(dummy(0).isRight)
-    assert(dummy(1).isLeft)
+    assert(dummy(0).isLeft)
+    assert(dummy(1).isRight)
   }
 }

--- a/main/test/src/io/github/iltotore/iron/test/RuntimeSpec.scala
+++ b/main/test/src/io/github/iltotore/iron/test/RuntimeSpec.scala
@@ -12,4 +12,12 @@ class RuntimeSpec extends UnitSpec {
     assert(dummy(0).isRight)
     assert(dummy(1).isLeft)
   }
+
+  "A Not[B] constraint" should "return Right if the argument doesn't pass " in {
+
+    def dummy(x: Int ==> Equal[0]): Int ==> Equal[0] = x
+
+    assert(dummy(0).isRight)
+    assert(dummy(1).isLeft)
+  }
 }

--- a/main/test/src/io/github/iltotore/iron/test/package.scala
+++ b/main/test/src/io/github/iltotore/iron/test/package.scala
@@ -5,8 +5,20 @@ import io.github.iltotore.iron.constraint.Constraint
 package object test {
 
   trait Dummy
+
   inline given Constraint[Boolean, Dummy] with {
     override inline def assert(value: Boolean): Boolean = value
   }
-  
+
+  trait Positive
+
+  inline given Constraint[Int, Positive] with {
+    override inline def assert(value: Int): Boolean = value > 0
+  }
+
+  trait Even
+
+  inline given Constraint[Int, Even] with {
+    override inline def assert(value: Int): Boolean = value % 2 == 0
+  }
 }


### PR DESCRIPTION
This pull request provides the following constraints:
- `Not[B]`: Reverse the constraint represented by `B`
- `Or[B, C]` alias `||`: Pass if the input satisfies `B` or `C` one.
- `And[B, C]` alias `&&`: Pass if the input satisfies both `B` and `C`

These new boolean-like constraints allow constraint composition for complex cases.