### PR TITLE
String module for Iron

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -182,3 +182,10 @@ object numeric extends IronModule {
 
   object test extends Tests with ScalaTest
 }
+
+object string extends IronModule {
+
+  def subVersion = "0.1.0"
+
+  object test extends Tests with ScalaTest
+}

--- a/numeric/README.md
+++ b/numeric/README.md
@@ -1,4 +1,5 @@
 # Iron Numeric
+
 [![iron-numeric Scala version support](https://index.scala-lang.org/iltotore/iron/iron-numeric/latest-by-scala-version.svg)](https://index.scala-lang.org/iltotore/iron/iron-numeric)
 
 This module includes numeric utils for Iron.
@@ -9,7 +10,7 @@ This module includes numeric utils for Iron.
 - [Numeric constraints](https://iltotore.github.io/iron/scaladoc/api/io/github/iltotore/iron/numeric/constraint$.html)
 - [Number abstraction](https://iltotore.github.io/iron/scaladoc/api/io/github/iltotore/iron/numeric.html#Number-0)
   for constraint creation
-  
+
 ## Import in your project
 
 <details>

--- a/string/README.md
+++ b/string/README.md
@@ -1,0 +1,31 @@
+# Iron String
+
+[![iron-string Scala version support](https://index.scala-lang.org/iltotore/iron/iron-string/latest-by-scala-version.svg)](https://index.scala-lang.org/iltotore/iron/iron-string)
+
+This module includes String-related utils for Iron.
+
+
+## Features
+
+- [Scaladoc](https://iltotore.github.io/iron/scaladoc/api/io/github/iltotore/iron/constraint.html)
+- [String constraints](https://iltotore.github.io/iron/scaladoc/api/io/github/iltotore/iron/string/constraint$.html)
+
+## Import in your project
+
+<details>
+<summary>SBT</summary>
+
+```scala
+libraryDependencies += "io.github.iltotore" %% "iron-string" % "version"
+```
+
+</details>
+
+<details>
+<summary>Mill</summary>
+
+```scala
+ivy"io.github.iltotore::iron-string:version"
+```
+
+</details>

--- a/string/src/io/github/iltotore/iron/string/constraint.scala
+++ b/string/src/io/github/iltotore/iron/string/constraint.scala
@@ -1,0 +1,13 @@
+package io.github.iltotore.iron.string
+
+import io.github.iltotore.iron.==>
+import io.github.iltotore.iron.constraint.Constraint
+
+object constraint {
+
+  trait LowerCase
+
+  inline given Constraint.RuntimeOnly[String, LowerCase] with {
+    override inline def assert(value: String): Boolean = value equals value.toLowerCase
+  }
+}

--- a/string/src/io/github/iltotore/iron/string/constraint.scala
+++ b/string/src/io/github/iltotore/iron/string/constraint.scala
@@ -22,8 +22,8 @@ object constraint {
   trait Match[V]
 
   type Alphanumeric = Match["^[a-z0-9]+"]
-  type URLLike = Match[raw"^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$"]
-  type UUIDLike = Match[raw"^([0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12})"]
+  type URLLike = Match["^(?:http(s)?:\\/\\/)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$"]
+  type UUIDLike = Match["^([0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12})"]
 
   inline given [V <: String]: Constraint.RuntimeOnly[String, Match[V]] with {
     override inline def assert(value: String): Boolean = constValue[V].r.matches(value)

--- a/string/src/io/github/iltotore/iron/string/constraint.scala
+++ b/string/src/io/github/iltotore/iron/string/constraint.scala
@@ -3,11 +3,19 @@ package io.github.iltotore.iron.string
 import io.github.iltotore.iron.==>
 import io.github.iltotore.iron.constraint.Constraint
 
+import scala.compiletime.constValue
+
 object constraint {
 
   trait LowerCase
 
   inline given Constraint.RuntimeOnly[String, LowerCase] with {
     override inline def assert(value: String): Boolean = value equals value.toLowerCase
+  }
+
+  trait UpperCase
+
+  inline given Constraint.RuntimeOnly[String, UpperCase] with {
+    override inline def assert(value: String): Boolean = value equals value.toUpperCase
   }
 }

--- a/string/src/io/github/iltotore/iron/string/constraint.scala
+++ b/string/src/io/github/iltotore/iron/string/constraint.scala
@@ -7,18 +7,28 @@ import scala.compiletime.constValue
 
 object constraint {
 
+  /**
+   * Constraint: checks if the input value is lower case.
+   */
   trait LowerCase
 
   inline given Constraint.RuntimeOnly[String, LowerCase] with {
     override inline def assert(value: String): Boolean = value equals value.toLowerCase
   }
 
+  /**
+   * Constraint: checks if the input value is upper case.
+   */
   trait UpperCase
 
   inline given Constraint.RuntimeOnly[String, UpperCase] with {
     override inline def assert(value: String): Boolean = value equals value.toUpperCase
   }
 
+  /**
+   * Constraint: checks if the input value matches V.
+   * @tparam V the regex to match with.
+   */
   trait Match[V]
 
   type Alphanumeric = Match["^[a-z0-9]+"]

--- a/string/src/io/github/iltotore/iron/string/constraint.scala
+++ b/string/src/io/github/iltotore/iron/string/constraint.scala
@@ -18,4 +18,14 @@ object constraint {
   inline given Constraint.RuntimeOnly[String, UpperCase] with {
     override inline def assert(value: String): Boolean = value equals value.toUpperCase
   }
+
+  trait Match[V]
+
+  type Alphanumeric = Match["^[a-z0-9]+"]
+  type URLLike = Match[raw"^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$"]
+  type UUIDLike = Match[raw"^([0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12})"]
+
+  inline given [V <: String]: Constraint.RuntimeOnly[String, Match[V]] with {
+    override inline def assert(value: String): Boolean = constValue[V].r.matches(value)
+  }
 }

--- a/string/test/src/io/github/iltotore/iron/test/string/RuntimeSpec.scala
+++ b/string/test/src/io/github/iltotore/iron/test/string/RuntimeSpec.scala
@@ -1,0 +1,16 @@
+package io.github.iltotore.iron.test.string
+
+import io.github.iltotore.iron.*, constraint.*, string.constraint.*
+import io.github.iltotore.iron.test.UnitSpec
+
+class RuntimeSpec extends UnitSpec {
+
+
+  "A LowerCase constraint" should "return Right if the argument is lower case" in {
+
+    def dummy(x: String ==> LowerCase): String ==> LowerCase = x
+
+    assert(dummy("abc").isRight)
+    assert(dummy("ABC").isLeft)
+  }
+}

--- a/string/test/src/io/github/iltotore/iron/test/string/RuntimeSpec.scala
+++ b/string/test/src/io/github/iltotore/iron/test/string/RuntimeSpec.scala
@@ -5,7 +5,6 @@ import io.github.iltotore.iron.test.UnitSpec
 
 class RuntimeSpec extends UnitSpec {
 
-
   "A LowerCase constraint" should "return Right if the argument is lower case" in {
 
     def dummy(x: String ==> LowerCase): String ==> LowerCase = x
@@ -21,5 +20,15 @@ class RuntimeSpec extends UnitSpec {
     assert(dummy("ABC").isRight)
     assert(dummy("abc").isLeft)
   }
-  
+
+  "A Matcher[V] constraint" should "return Right if the argument matches the given V regex" in {
+
+    def dummy(x: String ==> Match["^[a-z0-9]+"]): String ==> Match["^[a-z0-9]+"] = x
+
+    assert(dummy("abc123").isRight)
+    assert(dummy("abc").isRight)
+    assert(dummy("123").isRight)
+    assert(dummy(" ").isLeft)
+    assert(dummy("$!#").isLeft)
+  }
 }

--- a/string/test/src/io/github/iltotore/iron/test/string/RuntimeSpec.scala
+++ b/string/test/src/io/github/iltotore/iron/test/string/RuntimeSpec.scala
@@ -13,4 +13,13 @@ class RuntimeSpec extends UnitSpec {
     assert(dummy("abc").isRight)
     assert(dummy("ABC").isLeft)
   }
+
+  "An UpperCase constraint" should "return Right if the argument is upper case" in {
+
+    def dummy(x: String ==> UpperCase): String ==> UpperCase = x
+
+    assert(dummy("ABC").isRight)
+    assert(dummy("abc").isLeft)
+  }
+  
 }


### PR DESCRIPTION
This pull request adds `iron-string`, a String-related module for Iron.

It provides type constraints for String:
- LowerCase
- UpperCase
- Match[V] where V is a regex