### PR TITLE
Add iterable module

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -189,3 +189,10 @@ object string extends IronModule {
 
   object test extends Tests with ScalaTest
 }
+
+object iterable extends IronModule {
+
+  def subVersion = "0.1.0"
+
+  object test extends Tests with ScalaTest
+}

--- a/iterable/README.md
+++ b/iterable/README.md
@@ -1,0 +1,30 @@
+# Iron Iterable
+
+[![iron-iterable Scala version support](https://index.scala-lang.org/iltotore/iron/iron-iterable/latest-by-scala-version.svg)](https://index.scala-lang.org/iltotore/iron/iron-iterable)
+
+This module includes iterable/collection utils for Iron.
+
+## Features
+
+- [Scaladoc](https://iltotore.github.io/iron/scaladoc/api/io/github/iltotore/iron/iterable.html)
+- [Iterable-related constraints](https://iltotore.github.io/iron/scaladoc/api/io/github/iltotore/iron/iterable/constraint$.html)
+
+## Import in your project
+
+<details>
+<summary>SBT</summary>
+
+```scala
+libraryDependencies += "io.github.iltotore" %% "iron-iterable" % "version"
+```
+
+</details>
+
+<details>
+<summary>Mill</summary>
+
+```scala
+ivy"io.github.iltotore::iron-iterable:version"
+```
+
+</details>

--- a/iterable/src/io/github/iltotore/iron/iterable/constraint.scala
+++ b/iterable/src/io/github/iltotore/iron/iterable/constraint.scala
@@ -8,18 +8,30 @@ import scala.collection.Iterable
 
 object constraint {
 
+  /**
+   * Constraint: checks if the input has a size greater or equal to V
+   * @tparam V
+   */
   trait MinSize[V]
 
   inline given [T, A <: Iterable[T], V <: Int]: Constraint.RuntimeOnly[A, MinSize[V]] with {
     override inline def assert(value: A): Boolean = value.size >= constValue[V]
   }
 
+  /**
+   * Constraint: checks if the input has a size lesser or equal to V
+   * @tparam V
+   */
   trait MaxSize[V]
 
   inline given [T, A <: Iterable[T], V <: Int]: Constraint.RuntimeOnly[A, MaxSize[V]] with {
     override inline def assert(value: A): Boolean = value.size <= constValue[V]
   }
 
+  /**
+   * Constraint: checks if the input has a size of V
+   * @tparam V
+   */
   trait Size[V]
 
   inline given [T, A <: Iterable[T], V <: Int]: Constraint.RuntimeOnly[A, Size[V]] with {

--- a/iterable/src/io/github/iltotore/iron/iterable/constraint.scala
+++ b/iterable/src/io/github/iltotore/iron/iterable/constraint.scala
@@ -38,6 +38,8 @@ object constraint {
     override inline def assert(value: A): Boolean = value.size == constValue[V]
   }
 
+  type Empty = Size[0]
+
   /**
    * Constraint: checks if the input contains V
    * @tparam V

--- a/iterable/src/io/github/iltotore/iron/iterable/constraint.scala
+++ b/iterable/src/io/github/iltotore/iron/iterable/constraint.scala
@@ -1,0 +1,16 @@
+package io.github.iltotore.iron.iterable
+
+import io.github.iltotore.iron.==>
+import io.github.iltotore.iron.constraint.Constraint
+
+import scala.compiletime.constValue
+import scala.collection.Iterable
+
+object constraint {
+
+  trait MinSize[V]
+
+  inline given [T, A <: Iterable[T], V <: Int]: Constraint.RuntimeOnly[A, MinSize[V]] with {
+    override inline def assert(value: A): Boolean = value.size >= constValue[V]
+  }
+}

--- a/iterable/src/io/github/iltotore/iron/iterable/constraint.scala
+++ b/iterable/src/io/github/iltotore/iron/iterable/constraint.scala
@@ -37,4 +37,14 @@ object constraint {
   inline given [T, A <: Iterable[T], V <: Int]: Constraint.RuntimeOnly[A, Size[V]] with {
     override inline def assert(value: A): Boolean = value.size == constValue[V]
   }
+
+  /**
+   * Constraint: checks if the input contains V
+   * @tparam V
+   */
+  trait Contains[V]
+
+  inline given [T, A <: Iterable[T], V <: T]: Constraint.RuntimeOnly[A, Contains[V]] with {
+    override inline def assert(value: A): Boolean = value.iterator.contains(constValue[V])
+  }
 }

--- a/iterable/src/io/github/iltotore/iron/iterable/constraint.scala
+++ b/iterable/src/io/github/iltotore/iron/iterable/constraint.scala
@@ -19,4 +19,10 @@ object constraint {
   inline given [T, A <: Iterable[T], V <: Int]: Constraint.RuntimeOnly[A, MaxSize[V]] with {
     override inline def assert(value: A): Boolean = value.size <= constValue[V]
   }
+
+  trait Size[V]
+
+  inline given [T, A <: Iterable[T], V <: Int]: Constraint.RuntimeOnly[A, Size[V]] with {
+    override inline def assert(value: A): Boolean = value.size == constValue[V]
+  }
 }

--- a/iterable/src/io/github/iltotore/iron/iterable/constraint.scala
+++ b/iterable/src/io/github/iltotore/iron/iterable/constraint.scala
@@ -13,4 +13,10 @@ object constraint {
   inline given [T, A <: Iterable[T], V <: Int]: Constraint.RuntimeOnly[A, MinSize[V]] with {
     override inline def assert(value: A): Boolean = value.size >= constValue[V]
   }
+
+  trait MaxSize[V]
+
+  inline given [T, A <: Iterable[T], V <: Int]: Constraint.RuntimeOnly[A, MaxSize[V]] with {
+    override inline def assert(value: A): Boolean = value.size <= constValue[V]
+  }
 }

--- a/iterable/test/src/io/github/iltotore/iron/test/iterable/RuntimeSpec.scala
+++ b/iterable/test/src/io/github/iltotore/iron/test/iterable/RuntimeSpec.scala
@@ -31,4 +31,12 @@ class RuntimeSpec extends UnitSpec {
     assert(dummy(0 until 2).isLeft)
     assert(dummy(0 until 5).isLeft)
   }
+
+  "A Contains[V] constraint" should "return Right if the argument contains V" in {
+
+    def dummy(x: Iterable[Int] ==> Contains[2]): Iterable[Int] ==> Contains[2] = x
+
+    assert(dummy(Seq(1, 2, 3)).isRight)
+    assert(dummy(Seq(1, 3, 4)).isLeft)
+  }
 }

--- a/iterable/test/src/io/github/iltotore/iron/test/iterable/RuntimeSpec.scala
+++ b/iterable/test/src/io/github/iltotore/iron/test/iterable/RuntimeSpec.scala
@@ -22,4 +22,13 @@ class RuntimeSpec extends UnitSpec {
     assert(dummy(0 until 2).isRight)
     assert(dummy(0 until 5).isLeft)
   }
+
+  "A Size[V] constraint" should "return Right if the argument has a size of V" in {
+
+    def dummy(x: Iterable[Int] ==> Size[3]): Iterable[Int] ==> Size[3] = x
+
+    assert(dummy(0 until 3).isRight)
+    assert(dummy(0 until 2).isLeft)
+    assert(dummy(0 until 5).isLeft)
+  }
 }

--- a/iterable/test/src/io/github/iltotore/iron/test/iterable/RuntimeSpec.scala
+++ b/iterable/test/src/io/github/iltotore/iron/test/iterable/RuntimeSpec.scala
@@ -1,0 +1,16 @@
+package io.github.iltotore.iron.test.iterable
+
+import io.github.iltotore.iron.*, constraint.*, iterable.constraint.*
+import io.github.iltotore.iron.test.UnitSpec
+
+class RuntimeSpec extends UnitSpec {
+
+  "A MinSize[V] constraint" should "return Right if the argument has a size greater than V" in {
+
+    def dummy(x: Iterable[Int] ==> MinSize[3]): Iterable[Int] ==> MinSize[3] = x
+
+    assert(dummy(0 until 3).isRight)
+    assert(dummy(0 until 5).isRight)
+    assert(dummy(0 until 2).isLeft)
+  }
+}

--- a/iterable/test/src/io/github/iltotore/iron/test/iterable/RuntimeSpec.scala
+++ b/iterable/test/src/io/github/iltotore/iron/test/iterable/RuntimeSpec.scala
@@ -5,12 +5,21 @@ import io.github.iltotore.iron.test.UnitSpec
 
 class RuntimeSpec extends UnitSpec {
 
-  "A MinSize[V] constraint" should "return Right if the argument has a size greater than V" in {
+  "A MinSize[V] constraint" should "return Right if the argument has a size greater or equal to V" in {
 
     def dummy(x: Iterable[Int] ==> MinSize[3]): Iterable[Int] ==> MinSize[3] = x
 
     assert(dummy(0 until 3).isRight)
     assert(dummy(0 until 5).isRight)
     assert(dummy(0 until 2).isLeft)
+  }
+
+  "A MaxSize[V] constraint" should "return Right if the argument has a size lesser or equal to V" in {
+
+    def dummy(x: Iterable[Int] ==> MaxSize[3]): Iterable[Int] ==> MaxSize[3] = x
+
+    assert(dummy(0 until 3).isRight)
+    assert(dummy(0 until 2).isRight)
+    assert(dummy(0 until 5).isLeft)
   }
 }


### PR DESCRIPTION
This Pull Request adds an iterable-related module for Iron. It includes custom constraints for Iterables:
- MinSize[V]
- MaxSize[V]
- Size[V]
- Empty = Size[0]
- Contains[V]

Related: #9 