### PR TITLE
Improve error handling system

### DIFF
--- a/iterable/src/io/github/iltotore/iron/iterable/constraint.scala
+++ b/iterable/src/io/github/iltotore/iron/iterable/constraint.scala
@@ -16,6 +16,8 @@ object constraint {
 
   inline given [T, A <: Iterable[T], V <: Int]: Constraint.RuntimeOnly[A, MinSize[V]] with {
     override inline def assert(value: A): Boolean = value.size >= constValue[V]
+
+    override inline def getMessage(value: A): String = s"Length should be greater or equal to ${constValue[V]}"
   }
 
   /**
@@ -26,6 +28,8 @@ object constraint {
 
   inline given [T, A <: Iterable[T], V <: Int]: Constraint.RuntimeOnly[A, MaxSize[V]] with {
     override inline def assert(value: A): Boolean = value.size <= constValue[V]
+
+    override inline def getMessage(value: A): String = s"Length should be less or equal to ${constValue[V]}"
   }
 
   /**
@@ -36,6 +40,8 @@ object constraint {
 
   inline given [T, A <: Iterable[T], V <: Int]: Constraint.RuntimeOnly[A, Size[V]] with {
     override inline def assert(value: A): Boolean = value.size == constValue[V]
+
+    override inline def getMessage(value: A): String = s"Length should equal to ${constValue[V]}"
   }
 
   type Empty = Size[0]
@@ -48,5 +54,7 @@ object constraint {
 
   inline given [T, A <: Iterable[T], V <: T]: Constraint.RuntimeOnly[A, Contains[V]] with {
     override inline def assert(value: A): Boolean = value.iterator.contains(constValue[V])
+
+    override inline def getMessage(value: A): String = s"Iterable should contain ${constValue[V]}"
   }
 }

--- a/main/src/io/github/iltotore/iron/constraint/Constraint.scala
+++ b/main/src/io/github/iltotore/iron/constraint/Constraint.scala
@@ -20,6 +20,8 @@ trait Constraint[A, B] {
    * @return true if the assertion is passed, false otherwise
    */
   inline def runtimeAssert(value: A): Boolean = assert(value)
+
+  inline def getMessage(value: A): String
 }
 
 object Constraint {

--- a/main/src/io/github/iltotore/iron/constraint/Constraint.scala
+++ b/main/src/io/github/iltotore/iron/constraint/Constraint.scala
@@ -21,6 +21,13 @@ trait Constraint[A, B] {
    */
   inline def runtimeAssert(value: A): Boolean = assert(value)
 
+  /**
+   * Generate the assertion message using `value`.
+   * @param value the input value
+   * @return the message describing this Constraint
+   * @note For compile-time constraints, you should use only litteral strings to allow the macro to get the value at
+   *       compile-time (and print it correctly when a compile-time error occurs).
+   */
   inline def getMessage(value: A): String
 }
 

--- a/main/src/io/github/iltotore/iron/constraint/IllegalValueError.scala
+++ b/main/src/io/github/iltotore/iron/constraint/IllegalValueError.scala
@@ -6,4 +6,4 @@ package io.github.iltotore.iron.constraint
  * @param constraint the type constraint applied to [[input]]
  * @tparam A the input type
  */
-case class IllegalValueError[A](input: A, constraint: Constraint[A, ?]) extends Error
+case class IllegalValueError[A](input: A, message: String) extends Error(message)

--- a/main/src/io/github/iltotore/iron/constraint/package.scala
+++ b/main/src/io/github/iltotore/iron/constraint/package.scala
@@ -42,6 +42,8 @@ package object constraint {
   class StrictEqualConstraint[A, V <: A] extends Constraint[A, StrictEqual[V]] {
 
     override inline def assert(value: A): Boolean = value == constValue[V]
+
+    override inline def getMessage(value: A): String = s"$value should strictly equal to ${constValue[V]}"
   }
 
   inline given[A, V <: A]: StrictEqualConstraint[A, V] = new StrictEqualConstraint
@@ -58,6 +60,8 @@ package object constraint {
   class EqualConstraint[A, V <: A] extends Constraint[A, Equal[V]] {
 
     override inline def assert(value: A): Boolean = value equals constValue[V]
+
+    override inline def getMessage(value: A): String = s"$value should equal to ${constValue[V]}"
   }
 
   inline given[A, V <: A]: EqualConstraint[A, V] = new EqualConstraint
@@ -75,6 +79,8 @@ package object constraint {
   class NotConstraint[A, B, C <: Constraint[A, B]](using constraint: C) extends Constraint[A, Not[B]] {
 
     override inline def assert(value: A): Boolean = !constraint.assert(value)
+
+    override inline def getMessage(value: A): String = s"Not: ${constraint.getMessage(value)}"
   }
 
   inline given[A, B, C <: Constraint[A, B]](using C): NotConstraint[A, B, C] = new NotConstraint
@@ -93,6 +99,8 @@ package object constraint {
   class OrConstraint[A, B, C, CB <: Constraint[A, B], CC <: Constraint[A, C]](using left: CB, right: CC) extends Constraint[A, Or[B, C]] {
 
     override inline def assert(value: A): Boolean = left.assert(value) || right.assert(value)
+
+    override inline def getMessage(value: A): String = s"${left.getMessage(value)} or ${right.getMessage(value)}"
   }
 
   inline given[A, B, C, CB <: Constraint[A, B], CC <: Constraint[A, C]](using CB, CC): OrConstraint[A, B, C, CB, CC] = new OrConstraint
@@ -111,6 +119,8 @@ package object constraint {
   class AndConstraint[A, B, C, CB <: Constraint[A, B], CC <: Constraint[A, C]](using left: CB, right: CC) extends Constraint[A, And[B, C]] {
 
     override inline def assert(value: A): Boolean = left.assert(value) && right.assert(value)
+
+    override inline def getMessage(value: A): String = s"${left.getMessage(value)} and ${right.getMessage(value)}"
   }
 
   inline given[A, B, C, CB <: Constraint[A, B], CC <: Constraint[A, C]](using CB, CC): AndConstraint[A, B, C, CB, CC] = new AndConstraint

--- a/main/src/io/github/iltotore/iron/constraint/package.scala
+++ b/main/src/io/github/iltotore/iron/constraint/package.scala
@@ -25,6 +25,7 @@ package object constraint {
 
     /**
      * Ensure that `a` passes B's constraint
+     *
      * @tparam B the constraint's dummy
      * @return the value as Constrained
      * @see [[refineValue]]
@@ -34,9 +35,11 @@ package object constraint {
 
   /**
    * Constraint: checks if the input value strictly equals to V.
+   *
    * @tparam V
    */
   trait StrictEqual[V]
+
   type ==[A, V] = A ==> StrictEqual[V]
 
   class StrictEqualConstraint[A, V <: A] extends Constraint[A, StrictEqual[V]] {
@@ -124,4 +127,23 @@ package object constraint {
   }
 
   inline given[A, B, C, CB <: Constraint[A, B], CC <: Constraint[A, C]](using CB, CC): AndConstraint[A, B, C, CB, CC] = new AndConstraint
+
+  /**
+   * Constraint: attaches a custom description to the given constraint. Useful when a constraint alias need a more
+   * accurate description.
+   *
+   * @tparam B the wrapped constraint's dummy
+   * @tparam V the description to attach. Must be litteral.
+   * @note This constraint is runtime only.
+   */
+  trait DescribedAs[B, V]
+
+  class DescribedAsConstraint[A, B, C <: Constraint[A, B], V <: String](using constraint: C) extends Constraint.RuntimeOnly[A, DescribedAs[B, V]] {
+
+    override inline def assert(value: A): Boolean = constraint.assert(value)
+
+    override inline def getMessage(value: A): String = constValue[V]
+  }
+
+  inline given[A, B, C <: Constraint[A, B], V <: String](using C): DescribedAsConstraint[A, B, C, V] = new DescribedAsConstraint
 }

--- a/main/test/src/io/github/iltotore/iron/test/main/package.scala
+++ b/main/test/src/io/github/iltotore/iron/test/main/package.scala
@@ -8,11 +8,15 @@ package object main {
 
   inline given Constraint[Int, Positive] with {
     override inline def assert(value: Int): Boolean = value > 0
+
+    override inline def getMessage(value: Int): String = s"$value should be positive"
   }
 
   trait Even
 
   inline given Constraint[Int, Even] with {
     override inline def assert(value: Int): Boolean = value % 2 == 0
+
+    override inline def getMessage(value: Int): String = s"$value should be even"
   }
 }

--- a/numeric/src/io/github/iltotore/iron/numeric/constraint.scala
+++ b/numeric/src/io/github/iltotore/iron/numeric/constraint.scala
@@ -17,6 +17,8 @@ object constraint {
 
   class LessConstraint[A <: Number, V <: A] extends Constraint[A, Less[V]] {
     override inline def assert(value: A): Boolean = NumberOrdering.lt(value, constValue[V])
+
+    override inline def getMessage(value: A): String = "value should be less than the specified value"
   }
 
   inline given[A <: Number, V <: A]: LessConstraint[A, V] = new LessConstraint
@@ -32,6 +34,8 @@ object constraint {
 
   class LessEqualConstraint[A <: Number, V <: A] extends Constraint[A, LessEqual[V]] {
     override inline def assert(value: A): Boolean = NumberOrdering.lteq(value, constValue[V])
+
+    override inline def getMessage(value: A): String = "value should be less or equal to the specified value"
   }
 
   inline given[A <: Number, V <: A]: LessEqualConstraint[A, V] = new LessEqualConstraint
@@ -58,6 +62,8 @@ object constraint {
 
   class GreaterConstraint[A <: Number, V <: A] extends Constraint[A, Greater[V]] {
     override inline def assert(value: A): Boolean = NumberOrdering.gt(value, constValue[V])
+
+    override inline def getMessage(value: A): String = "value should be greater than the specified value"
   }
 
   inline given[A <: Number, V <: A]: GreaterConstraint[A, V] = new GreaterConstraint
@@ -84,6 +90,8 @@ object constraint {
 
   class GreaterEqualConstraint[A <: Number, V <: A] extends Constraint[A, GreaterEqual[V]] {
     override inline def assert(value: A): Boolean = NumberOrdering.gteq(value, constValue[V])
+
+    override inline def getMessage(value: A): String = "value should be greater or equal to the specified value"
   }
 
   inline given[A <: Number, V <: A]: GreaterEqualConstraint[A, V] = new GreaterEqualConstraint
@@ -109,6 +117,8 @@ object constraint {
 
   class DivisibleConstraint[A <: Number, V <: A] extends Constraint[A, Divisible[V]] {
     override inline def assert(value: A): Boolean = modulo(value, constValue[V]) == 0
+
+    override inline def getMessage(value: A): String = "value should be divisible by the specified value"
   }
 
   inline given[A <: Number, V <: A]: DivisibleConstraint[A, V] = new DivisibleConstraint

--- a/string/src/io/github/iltotore/iron/string/constraint.scala
+++ b/string/src/io/github/iltotore/iron/string/constraint.scala
@@ -14,6 +14,8 @@ object constraint {
 
   inline given Constraint.RuntimeOnly[String, LowerCase] with {
     override inline def assert(value: String): Boolean = value equals value.toLowerCase
+
+    override inline def getMessage(value: String): String = s"$value should be lower cased"
   }
 
   /**
@@ -23,6 +25,8 @@ object constraint {
 
   inline given Constraint.RuntimeOnly[String, UpperCase] with {
     override inline def assert(value: String): Boolean = value equals value.toUpperCase
+
+    override inline def getMessage(value: String): String = s"$value should be upper cased"
   }
 
   /**
@@ -37,5 +41,7 @@ object constraint {
 
   inline given [V <: String]: Constraint.RuntimeOnly[String, Match[V]] with {
     override inline def assert(value: String): Boolean = constValue[V].r.matches(value)
+
+    override inline def getMessage(value: String): String = s"$value should match ${constValue[V]}"
   }
 }

--- a/string/src/io/github/iltotore/iron/string/constraint.scala
+++ b/string/src/io/github/iltotore/iron/string/constraint.scala
@@ -35,7 +35,7 @@ object constraint {
    */
   trait Match[V]
 
-  type Alphanumeric = Match["^[a-z0-9]+"]
+  type Alphanumeric = Match["^[a-zA-Z0-9]+"]
   type URLLike = Match["^(?:http(s)?:\\/\\/)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$"]
   type UUIDLike = Match["^([0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12})"]
 

--- a/string/src/io/github/iltotore/iron/string/constraint.scala
+++ b/string/src/io/github/iltotore/iron/string/constraint.scala
@@ -1,7 +1,7 @@
 package io.github.iltotore.iron.string
 
 import io.github.iltotore.iron.==>
-import io.github.iltotore.iron.constraint.Constraint
+import io.github.iltotore.iron.constraint.*
 
 import scala.compiletime.constValue
 
@@ -35,9 +35,13 @@ object constraint {
    */
   trait Match[V]
 
-  type Alphanumeric = Match["^[a-zA-Z0-9]+"]
-  type URLLike = Match["^(?:http(s)?:\\/\\/)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$"]
-  type UUIDLike = Match["^([0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12})"]
+  type Alphanumeric = Match["^[a-zA-Z0-9]+"] DescribedAs "Value should be alphanumeric"
+
+  type URLLike =
+    Match["^(?:http(s)?:\\/\\/)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$"] DescribedAs "Value should be an URL"
+
+  type UUIDLike =
+    Match["^([0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12})"] DescribedAs "Value should be an UUID"
 
   inline given [V <: String]: Constraint.RuntimeOnly[String, Match[V]] with {
     override inline def assert(value: String): Boolean = constValue[V].r.matches(value)

--- a/testCore/src/io/github/iltotore/iron/test/package.scala
+++ b/testCore/src/io/github/iltotore/iron/test/package.scala
@@ -8,17 +8,23 @@ package object test {
 
   inline given Constraint[Boolean, Dummy] with {
     override inline def assert(value: Boolean): Boolean = value
+
+    override inline def getMessage(value: Boolean): String = s"$value is false"
   }
 
   trait DummyCompileTime
 
   inline given Constraint.CompileTimeOnly[Boolean, DummyCompileTime] with {
     override inline def assert(value: Boolean): Boolean = value
+
+    override inline def getMessage(value: Boolean): String = s"$value is false"
   }
 
   trait DummyRuntime
 
   inline given Constraint.RuntimeOnly[Boolean, DummyRuntime] with {
     override inline def assert(value: Boolean): Boolean = value
+
+    override inline def getMessage(value: Boolean): String = s"$value is false"
   }
 }


### PR DESCRIPTION
Closes #15 

`Constraint#assert` still returns a Boolean and a `Constraint#getMessage` method was added instead to prevent regression of the compile-time evaluation system.