### PR TITLE
Fix compile/runtime only incoherence for Not/Or/And constraints

### DIFF
--- a/main/src/io/github/iltotore/iron/constraint/package.scala
+++ b/main/src/io/github/iltotore/iron/constraint/package.scala
@@ -79,7 +79,7 @@ package object constraint {
 
   type \[A, V] = A ==> Not[StrictEqual[V]]
 
-  class NotConstraint[A, B, C <: Constraint[A, B]](using constraint: C) extends Constraint[A, Not[B]] {
+  class NotConstraint[A, B, C <: Constraint[A, B]](using constraint: C) extends Constraint.RuntimeOnly[A, Not[B]] {
 
     override inline def assert(value: A): Boolean = !constraint.assert(value)
 

--- a/main/src/io/github/iltotore/iron/constraint/package.scala
+++ b/main/src/io/github/iltotore/iron/constraint/package.scala
@@ -99,7 +99,7 @@ package object constraint {
 
   type ||[B, C] = Or[B, C]
 
-  class OrConstraint[A, B, C, CB <: Constraint[A, B], CC <: Constraint[A, C]](using left: CB, right: CC) extends Constraint[A, Or[B, C]] {
+  class OrConstraint[A, B, C, CB <: Constraint[A, B], CC <: Constraint[A, C]](using left: CB, right: CC) extends Constraint.RuntimeOnly[A, Or[B, C]] {
 
     override inline def assert(value: A): Boolean = left.assert(value) || right.assert(value)
 
@@ -119,7 +119,7 @@ package object constraint {
 
   type &&[B, C] = And[B, C]
 
-  class AndConstraint[A, B, C, CB <: Constraint[A, B], CC <: Constraint[A, C]](using left: CB, right: CC) extends Constraint[A, And[B, C]] {
+  class AndConstraint[A, B, C, CB <: Constraint[A, B], CC <: Constraint[A, C]](using left: CB, right: CC) extends Constraint.RuntimeOnly[A, And[B, C]] {
 
     override inline def assert(value: A): Boolean = left.assert(value) && right.assert(value)
 


### PR DESCRIPTION
These constraints are now declared as RuntimeOnly to avoid confusion since their not fully inline.

Closes #25 