### PR TITLE
Add consequences

### DIFF
--- a/main/src/io/github/iltotore/iron/compileTime.scala
+++ b/main/src/io/github/iltotore/iron/compileTime.scala
@@ -17,9 +17,10 @@ object compileTime {
    * will be evaluated at runtime
    *
    * @param input the constrained input
-   * @param constraint the constraint to evaluate
+   * @param message the error message to throw if the result is false
+   * @param result the result of the assertion
    */
-  inline def preAssert[A, B, C <: Constraint[A, B]](inline input: A, inline constraint: C): Refined[A] = ${preAssertImpl[A, B, C]('input, '{constraint.getMessage(input)}, '{constraint.assert(input)})}
+  inline def preAssert[A, B, C <: Constraint[A, B]](inline input: A, inline message: String, inline result: Boolean): Refined[A] = ${preAssertImpl[A, B, C]('input, 'message, 'result)}
 
   private def preAssertImpl[A: Type, B: Type, C <: Constraint[A, B]: Type](input: Expr[A], message: Expr[String], result: Expr[Boolean])(using quotes: Quotes): Expr[Refined[A]] = {
 

--- a/main/src/io/github/iltotore/iron/compileTime.scala
+++ b/main/src/io/github/iltotore/iron/compileTime.scala
@@ -52,4 +52,11 @@ object compileTime {
 
     '{Either.cond($result, $input, IllegalValueError($input, $message))}
   }
+
+  inline def showType[T]: String = ${showTypeImpl[T]}
+
+  private def showTypeImpl[T : Type](using Quotes): Expr[String] = {
+    val repr = Type.show[T]
+    Expr(repr)
+  }
 }

--- a/main/src/io/github/iltotore/iron/constraint/Consequence.scala
+++ b/main/src/io/github/iltotore/iron/constraint/Consequence.scala
@@ -17,4 +17,14 @@ object Consequence {
   }
 
   inline def verified[A, B1, B2]: VerifiedConsequence[A, B1, B2] = new VerifiedConsequence
+  
+  
+  class InvalidConsequence[A, B1, B2] extends Consequence[A, B1, B2] {
+
+    override inline def assert(value: A): Boolean = false
+
+    override inline def getMessage(value: A): String = "invalid"
+  }
+  
+  inline def invalid[A, B1, B2]: InvalidConsequence[A, B1, B2] = new InvalidConsequence
 }

--- a/main/src/io/github/iltotore/iron/constraint/Consequence.scala
+++ b/main/src/io/github/iltotore/iron/constraint/Consequence.scala
@@ -1,0 +1,20 @@
+package io.github.iltotore.iron.constraint
+
+trait Consequence[A, B1, B2] {
+  
+  inline def assert(value: A): Boolean
+
+  inline def getMessage(value: A): String
+}
+
+object Consequence {
+
+  class VerifiedConsequence[A, B1, B2] extends Consequence[A, B1, B2] {
+
+    override inline def assert(value: A): Boolean = true
+
+    override inline def getMessage(value: A): String = "valid"
+  }
+
+  inline def verified[A, B1, B2]: VerifiedConsequence[A, B1, B2] = new VerifiedConsequence
+}

--- a/main/src/io/github/iltotore/iron/constraint/LowPriorityConsequence.scala
+++ b/main/src/io/github/iltotore/iron/constraint/LowPriorityConsequence.scala
@@ -1,0 +1,16 @@
+package io.github.iltotore.iron.constraint
+
+import scala.compiletime.summonInline
+
+trait LowPriorityConsequence {
+
+  class DefaultConsequence[A, B1, B2, C <: Constraint[A, B2]](using C) extends Consequence[A, B1, B2] {
+
+    override inline def assert(value: A): Boolean = summonInline[C].assert(value)
+
+    override inline def getMessage(value: A): String = summonInline[C].getMessage(value)
+  }
+
+  inline given defaultConsequence[A, B1, B2, Cons <: Constraint[A, B2]](using inline constraint: Cons): DefaultConsequence[A, B1, B2, Cons] = new DefaultConsequence
+
+}

--- a/main/src/io/github/iltotore/iron/constraint/package.scala
+++ b/main/src/io/github/iltotore/iron/constraint/package.scala
@@ -184,16 +184,6 @@ package object constraint extends LowPriorityConsequence {
   inline given[A, B, C, CB <: Constraint[A, B], CC <: Constraint[A, C]](using inline cb: CB, inline cc: CC): OrConstraint[A, B, C, CB, CC] = new OrConstraint
 
   /**
-   * B1 | B2 => B1
-   */
-  transparent inline given[A, B1, B2]: Consequence[A, Or[B1, B2], B1] = Consequence.verified
-
-  /**
-   * B1 | B2 => B2
-   */
-  transparent inline given[A, B1, B2]: Consequence[A, Or[B1, B2], B2] = Consequence.verified
-
-  /**
    * B1 => B1 | B2
    */
   transparent inline given[A, B1, B2]: Consequence[A, B1, Or[B1, B2]] = Consequence.verified

--- a/main/src/io/github/iltotore/iron/package.scala
+++ b/main/src/io/github/iltotore/iron/package.scala
@@ -106,7 +106,7 @@ package object iron {
    */
   implicit def unbox[A, B](constrained: A / B)(using RefinedDSL.type): A = constrained.fold(throw _, x => x)
   
-  implicit inline def refineConstrained[A, B1, B2](constrained: A / B1)(using inline consequence: Consequence[A, B1, B2]): A / B2 = constrained match {
+  implicit inline def refineConstrained[A, B1, B2, C <: Consequence[A, B1, B2]](constrained: A / B1)(using inline consequence: C): A / B2 = constrained match {
 
     case Right(value) => Constrained(compileTime.preAssert(value, consequence.getMessage(value), consequence.assert(value)))
 

--- a/main/test/src/io/github/iltotore/iron/test/main/CompileTimeSpec.scala
+++ b/main/test/src/io/github/iltotore/iron/test/main/CompileTimeSpec.scala
@@ -57,6 +57,16 @@ class CompileTimeSpec extends UnitSpec {
     "dummy(0)" shouldNot compile
   }
 
+  "B" should "not verify Not[B]" in {
+    val dummy: Boolean / Not[Dummy] = false
+    "val foo: Boolean / Dummy = dummy" shouldNot compile
+  }
+
+  "Not[B]" should "not verify B" in {
+    val dummy: Boolean / Dummy = true
+    "val foo: Boolean / Not[Dummy] = dummy" shouldNot compile
+  }
+
   "An Or[B, C] constraint" should "compile if the argument satisfies one of the two passed assertions" in {
 
     def dummy(x: Int / (StrictEqual[0] || StrictEqual[1])): Unit = ???
@@ -64,6 +74,13 @@ class CompileTimeSpec extends UnitSpec {
     "dummy(0)" should compile
     "dummy(1)" should compile
     "dummy(2)" shouldNot compile
+  }
+
+  "Both A and B" should "verify Or[A, B]" in {
+    val a: Int / Even = -2
+    val b: Int / Positive = 3
+    "val foo: Int / (Even || Positive) = a" should compile
+    "val foo: Int / (Even || Positive) = b" should compile
   }
 
   "An And[B, C] constraint" should "compile if the argument satisfies both B and C" in {
@@ -74,4 +91,12 @@ class CompileTimeSpec extends UnitSpec {
     "dummy(3)" shouldNot compile
     "dummy(-2)" shouldNot compile
   }
+
+  "And[A, B]" should "verify both A and B" in {
+
+    val dummy: Int / (Positive && Even) = 4
+    "val a: Int / Positive = dummy" should compile
+    "val b: Int / Even = dummy" should compile
+  }
+
 }

--- a/testCore/src/io/github/iltotore/iron/test/package.scala
+++ b/testCore/src/io/github/iltotore/iron/test/package.scala
@@ -25,6 +25,6 @@ package object test {
   inline given Constraint.RuntimeOnly[Boolean, DummyRuntime] with {
     override inline def assert(value: Boolean): Boolean = value
 
-    override inline def getMessage(value: Boolean): String = s"$value is false"
+    override inline def getMessage(value: Boolean): String = "value is false"
   }
 }


### PR DESCRIPTION
Add a new "consequence" system allowing the system to assume some properties based on the given Constrained. For example, `A / (B1 & B2)` requires no evaluation to become `A / B1` or `A / B2`.

Closes #38 