### PR TITLE
Compile time checking for string module

### DIFF
--- a/main/src/io/github/iltotore/iron/constraint/package.scala
+++ b/main/src/io/github/iltotore/iron/constraint/package.scala
@@ -312,7 +312,7 @@ package object constraint extends LowPriorityConsequence {
    * @tparam B the wrapped constraint's dummy
    * @tparam V the description to attach. Must be litteral.
    */
-  trait DescribedAs[B, V]
+  trait DescribedAs[+B, V]
 
   class DescribedAsConstraint[A, B, C <: Constraint[A, B], V <: String](using C) extends Constraint[A, DescribedAs[B, V]] {
 

--- a/string/src/io/github/iltotore/iron/string/compileTime.scala
+++ b/string/src/io/github/iltotore/iron/string/compileTime.scala
@@ -45,28 +45,4 @@ object compileTime {
     }
   }
 
-  transparent inline def extractRegex[T <: Match[_] | DescribedAs[Match[_], _]](): String = {
-    ${ extractRegexCode[T]() }
-  } 
-
-  def extractRegexCode[T]()(using Quotes, Type[T]): Expr[String] = {
-    import quotes.reflect.*
-    import io.github.iltotore.iron.string.constraint.Match
-
-    def extractFromConstant(typeRepr: TypeRepr): String = {
-      typeRepr match {
-        case ConstantType(StringConstant(s)) => s
-        case _ => report.throwError(typeRepr.show + " is not string contant")
-      }
-    }
-
-    val tpe = TypeRepr.of[T]
-    val regex = tpe.asType match {
-      case '[Match[v]] => extractFromConstant(TypeRepr.of[v])
-      case '[DescribedAs[Match[v], _]] => extractFromConstant(TypeRepr.of[v])
-      case _ => report.throwError(tpe.show + " is not Match or DescribedAs")
-    }
-    Expr(regex)
-  }
-
 }

--- a/string/src/io/github/iltotore/iron/string/compileTime.scala
+++ b/string/src/io/github/iltotore/iron/string/compileTime.scala
@@ -1,0 +1,110 @@
+package io.github.iltotore.iron.string
+
+import constraint.Match
+import scala.quoted._
+import scala.quoted.ToExpr.ClassToExpr
+import scala.deriving.Mirror
+import scala.reflect.ClassTag
+import io.github.iltotore.iron.constraint.DescribedAs
+
+object compileTime {
+
+  transparent inline def checkLowerCase(value: String): Boolean = {
+    ${ checkLowerCaseCode('value) }
+  }
+
+  def checkLowerCaseCode(valueExpr: Expr[String])(using q: Quotes): Expr[Boolean] = {
+    valueExpr.value match {
+      case Some(value) => Expr(value equals value.toLowerCase)
+      case None => '{ $valueExpr equals $valueExpr.toLowerCase }
+    }
+  }
+
+  transparent inline def checkUpperCase(value: String): Boolean = {
+    ${ checkUpperCaseCode('value) }
+  }
+
+  def checkUpperCaseCode(valueExpr: Expr[String])(using q: Quotes): Expr[Boolean] = {
+    valueExpr.value match {
+      case Some(value) => Expr(value equals value.toUpperCase)
+      case None => '{ $valueExpr equals $valueExpr.toUpperCase }
+    }
+  }
+
+  transparent inline def checkMatch(value: String, regex: String): Boolean = {
+    ${ checkMatchCode('value, 'regex) }
+  }
+
+  def checkMatchCode(valueExpr: Expr[String], regexExpr: Expr[String])(using q: Quotes): Expr[Boolean] = {
+    valueExpr.value match {
+      case Some(value) => 
+        //Regex is always const
+        val regex = regexExpr.valueOrError.r
+        Expr(regex.matches(value))
+      case None => '{ $valueExpr.matches($regexExpr) }
+    }
+  }
+
+  transparent inline def singleCheck42[T <: String & Singleton](using x: ClassTag[constraint.Match[T]]): T = scala.compiletime.constValue[T]
+
+  transparent inline def extractRegex[T <: Match[_] | DescribedAs[Match[_], _]](): String = {
+    ${ extractRegexCode[T]() }
+  } 
+
+  def extractRegexCode[T]()(using Quotes, Type[T]): Expr[String] = {
+    import quotes.reflect.*
+    import io.github.iltotore.iron.string.constraint.Match
+
+    def extractFromConstant(typeRepr: TypeRepr): String = {
+      typeRepr match {
+        case ConstantType(StringConstant(s)) => s
+        case _ => report.throwError(typeRepr.show + " is not string contant")
+      }
+    }
+
+    val tpe = TypeRepr.of[T]
+
+    val s = tpe.asType match {
+      case '[Match[v]] => extractFromConstant(TypeRepr.of[v])
+      case '[DescribedAs[Match[v], _]] => extractFromConstant(TypeRepr.of[v])
+      case _ => report.throwError(tpe.show + " is not Match or DescribedAs")
+    }
+
+    //   // Type.valueOfConstant
+
+    // val r = tpe.asType match 
+  
+    //   // case '[Map { type Map$K <: AnyRef; type Map$V = Int }] => "asd"
+    //   case '[constraint.Match[v] { type Match$V = a } ] => ???
+    //   case '[ constraint.Match[String] { type V = q }] => ???
+    //   case _ => "fail"
+    
+
+    // tpe.
+
+    // w match {
+      // case _: constraint.Match[_] => report.error("123")
+    // }
+
+    // w match {
+      // case '{ constraint.Match[V] { type V = v } } => Type.valueOfConstant[v]
+    // }
+
+    // println(tpe.show)
+
+    // report.error("2 " + r)
+
+    Expr(s)
+    // println(w)
+
+    // Expr("Abc")
+
+  //   '{ new io.github.iltotore.iron.constraint.Constraint[String, T] {
+  //   override def assert(value: String): Boolean = false
+
+  //   override def getMessage(value: String): String = "test"
+  // } 
+    
+  }
+
+}

--- a/string/src/io/github/iltotore/iron/string/compileTime.scala
+++ b/string/src/io/github/iltotore/iron/string/compileTime.scala
@@ -45,8 +45,6 @@ object compileTime {
     }
   }
 
-  transparent inline def singleCheck42[T <: String & Singleton](using x: ClassTag[constraint.Match[T]]): T = scala.compiletime.constValue[T]
-
   transparent inline def extractRegex[T <: Match[_] | DescribedAs[Match[_], _]](): String = {
     ${ extractRegexCode[T]() }
   } 
@@ -63,48 +61,12 @@ object compileTime {
     }
 
     val tpe = TypeRepr.of[T]
-
-    val s = tpe.asType match {
+    val regex = tpe.asType match {
       case '[Match[v]] => extractFromConstant(TypeRepr.of[v])
       case '[DescribedAs[Match[v], _]] => extractFromConstant(TypeRepr.of[v])
       case _ => report.throwError(tpe.show + " is not Match or DescribedAs")
     }
-
-    //   // Type.valueOfConstant
-
-    // val r = tpe.asType match 
-  
-    //   // case '[Map { type Map$K <: AnyRef; type Map$V = Int }] => "asd"
-    //   case '[constraint.Match[v] { type Match$V = a } ] => ???
-    //   case '[ constraint.Match[String] { type V = q }] => ???
-    //   case _ => "fail"
-    
-
-    // tpe.
-
-    // w match {
-      // case _: constraint.Match[_] => report.error("123")
-    // }
-
-    // w match {
-      // case '{ constraint.Match[V] { type V = v } } => Type.valueOfConstant[v]
-    // }
-
-    // println(tpe.show)
-
-    // report.error("2 " + r)
-
-    Expr(s)
-    // println(w)
-
-    // Expr("Abc")
-
-  //   '{ new io.github.iltotore.iron.constraint.Constraint[String, T] {
-  //   override def assert(value: String): Boolean = false
-
-  //   override def getMessage(value: String): String = "test"
-  // } 
-    
+    Expr(regex)
   }
 
 }

--- a/string/src/io/github/iltotore/iron/string/constraint.scala
+++ b/string/src/io/github/iltotore/iron/string/constraint.scala
@@ -38,28 +38,19 @@ object constraint {
 
   type Alphanumeric = Match["^[a-zA-Z0-9]+"] DescribedAs "Value should be alphanumeric"
 
-  inline given MatchConstraint[Alphanumeric] with {}
-
   type URLLike =
     Match["^(?:http(s)?:\\/\\/)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$"] DescribedAs "Value should be an URL"
-
-  inline given MatchConstraint[URLLike] with {}
 
   type UUIDLike =
     Match["^([0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12})"] DescribedAs "Value should be an UUID"
 
-  inline given MatchConstraint[UUIDLike] with {}
+  class MatchConstraint[V <: String & Singleton] extends Constraint[String, Match[V]] {
 
-  trait MatchConstraint[M <: Match[_] | DescribedAs[Match[_], _]] extends Constraint[String, M] {
-    override inline def assert(value: String): Boolean = compileTime.checkMatch(value, compileTime.extractRegex[M]())
+    override inline def assert(value: String): Boolean = compileTime.checkMatch(value, constValue[V])
 
-    override inline def getMessage(value: String): String = value + " should match " + compileTime.extractRegex[M]()
+    override inline def getMessage(value: String): String = value + " should match " + constValue[V]
   }
 
-  inline given [V <: String & Singleton](using NotGiven[MatchConstraint[Match[V]]]): Constraint.RuntimeOnly[String, Match[V]] with {
-    override inline def assert(value: String): Boolean = constValue[V].r.matches(value)
-
-    override inline def getMessage(value: String): String = s"$value should match ${constValue[V]}"
-  }
+  inline given [V <: String & Singleton]: MatchConstraint[V] = new MatchConstraint
 
 }

--- a/string/src/io/github/iltotore/iron/string/constraint.scala
+++ b/string/src/io/github/iltotore/iron/string/constraint.scala
@@ -34,7 +34,7 @@ object constraint {
    * Constraint: checks if the input value matches V.
    * @tparam V the regex to match with.
    */
-  trait Match[V <: String]
+  trait Match[V <: String & Singleton]
 
   type Alphanumeric = Match["^[a-zA-Z0-9]+"] DescribedAs "Value should be alphanumeric"
 
@@ -61,32 +61,5 @@ object constraint {
 
     override inline def getMessage(value: String): String = s"$value should match ${constValue[V]}"
   }
-
-  // transparent inline def getRegex[V <: String, Match[V]] = constValue[V]
-
-
-  // inline given Constraint[String, URLLike] with {
-  //   override inline def assert(value: String): Boolean = false
-
-  //   override inline def getMessage(value: String): String = "test"
-  // }
-
-
-  // inline given Constraint[String, URLLike] with {
-  //   override inline def assert(value: String): Boolean = {
-
-  //     inline val regex = compileTime.singleCheck42(URLLike)
-  //     // inline val a = getRegex[_, URLLike]
-  //     // val a = erasedValue[URLLike] match {
-  //     //   case _: Match[String] => "test"
-  //     // }
-  //     false
-  //     // BaseMatchConstraint.assert(value, constValue[URLLike])
-  //   }
-
-  //   override inline def getMessage(value: String): String = "test"
-  // }
-
-
 
 }

--- a/string/test/src/io/github/iltotore/iron/test/string/CompileTimeSpec.scala
+++ b/string/test/src/io/github/iltotore/iron/test/string/CompileTimeSpec.scala
@@ -23,26 +23,23 @@ class CompileTimeSpec extends UnitSpec {
 
   "A custom Match[V] without MatchConstraint" should "always compile" in {
 
-    def dummy(x: String / Match["^[a-z0-9]+"]): String / Match["^[a-z0-9]+"] = x
+    type NumberMatch = Match["^[0-9]+"]
+    def dummy(x: String / NumberMatch): String / NumberMatch = x
 
-    "dummy(\"abc123\")" should compile
-    "dummy(\"abc\")" should compile
     "dummy(\"123\")" should compile
     "dummy(\" \")" should compile
-    "dummy(\"$!#\")" should compile
+    "dummy(\"abc\")" should compile
   }
 
   "A custom Match[V] with MatchConstraint" should "detect regex at compile time" in {
 
-    type alphanumeric = Match["^[a-z0-9]+"]
-    def dummy(x: String / alphanumeric): String / alphanumeric = x
-    inline given MatchConstraint[alphanumeric] with {}
+    type NumberMatch = Match["^[0-9]+"]
+    def dummy(x: String / NumberMatch): String / NumberMatch = x
+    inline given MatchConstraint[NumberMatch] with {}
 
-    "dummy(\"abc123\")" should compile
-    "dummy(\"abc\")" should compile
     "dummy(\"123\")" should compile
     "dummy(\" \")" shouldNot compile
-    "dummy(\"$!#\")" shouldNot compile
+    "dummy(\"abc\")" shouldNot compile
   }
 
   "An URLLike constraint" should "return Right if the given String is a valid URL" in {

--- a/string/test/src/io/github/iltotore/iron/test/string/CompileTimeSpec.scala
+++ b/string/test/src/io/github/iltotore/iron/test/string/CompileTimeSpec.scala
@@ -1,0 +1,55 @@
+package io.github.iltotore.iron.test.string
+
+import io.github.iltotore.iron.*, constraint.{*, given}, string.constraint.{*, given}
+import io.github.iltotore.iron.test.UnitSpec
+
+class CompileTimeSpec extends UnitSpec {
+
+  "A LowerCase constraint" should "return Right if the argument is lower case" in {
+
+    def dummy(x: String / LowerCase): String / LowerCase = x
+
+    "dummy(\"abc\")" should compile 
+    "dummy(\"ABC\")" shouldNot compile
+  }
+
+  "An UpperCase constraint" should "return Right if the argument is upper case" in {
+
+    def dummy(x: String / UpperCase): String / UpperCase = x
+
+    "dummy(\"ABC\")" should compile 
+    "dummy(\"abc\")" shouldNot compile 
+  }
+
+  "A custom Match[V] without MatchConstraint" should "always compile" in {
+
+    def dummy(x: String / Match["^[a-z0-9]+"]): String / Match["^[a-z0-9]+"] = x
+
+    "dummy(\"abc123\")" should compile
+    "dummy(\"abc\")" should compile
+    "dummy(\"123\")" should compile
+    "dummy(\" \")" should compile
+    "dummy(\"$!#\")" should compile
+  }
+
+  "A custom Match[V] with MatchConstraint" should "detect regex at compile time" in {
+
+    type alphanumeric = Match["^[a-z0-9]+"]
+    def dummy(x: String / alphanumeric): String / alphanumeric = x
+    inline given MatchConstraint[alphanumeric] with {}
+
+    "dummy(\"abc123\")" should compile
+    "dummy(\"abc\")" should compile
+    "dummy(\"123\")" should compile
+    "dummy(\" \")" shouldNot compile
+    "dummy(\"$!#\")" shouldNot compile
+  }
+
+  "An URLLike constraint" should "return Right if the given String is a valid URL" in {
+
+    def dummy(x: String / URLLike): String / URLLike = x
+
+    """dummy("https://www.example.com")""" should compile
+    """dummy("http://invalid.com/perl.cgi?key=|")""" shouldNot compile
+  }
+}

--- a/string/test/src/io/github/iltotore/iron/test/string/CompileTimeSpec.scala
+++ b/string/test/src/io/github/iltotore/iron/test/string/CompileTimeSpec.scala
@@ -21,21 +21,10 @@ class CompileTimeSpec extends UnitSpec {
     "dummy(\"abc\")" shouldNot compile 
   }
 
-  "A custom Match[V] without MatchConstraint" should "always compile" in {
+  "A custom Match[V]" should "detect regex at compile time" in {
 
     type NumberMatch = Match["^[0-9]+"]
     def dummy(x: String / NumberMatch): String / NumberMatch = x
-
-    "dummy(\"123\")" should compile
-    "dummy(\" \")" should compile
-    "dummy(\"abc\")" should compile
-  }
-
-  "A custom Match[V] with MatchConstraint" should "detect regex at compile time" in {
-
-    type NumberMatch = Match["^[0-9]+"]
-    def dummy(x: String / NumberMatch): String / NumberMatch = x
-    inline given MatchConstraint[NumberMatch] with {}
 
     "dummy(\"123\")" should compile
     "dummy(\" \")" shouldNot compile

--- a/string/test/src/io/github/iltotore/iron/test/string/RuntimeSpec.scala
+++ b/string/test/src/io/github/iltotore/iron/test/string/RuntimeSpec.scala
@@ -7,7 +7,7 @@ class RuntimeSpec extends UnitSpec {
 
   "A LowerCase constraint" should "return Right if the argument is lower case" in {
 
-    def dummy(x: String / LowerCase): String / LowerCase = x
+    def dummy(x: String / RuntimeOnly[LowerCase]): String / LowerCase = x
 
     assert(dummy("abc").isRight)
     assert(dummy("ABC").isLeft)
@@ -15,7 +15,7 @@ class RuntimeSpec extends UnitSpec {
 
   "An UpperCase constraint" should "return Right if the argument is upper case" in {
 
-    def dummy(x: String / UpperCase): String / UpperCase = x
+    def dummy(x: String / RuntimeOnly[UpperCase]): String / UpperCase = x
 
     assert(dummy("ABC").isRight)
     assert(dummy("abc").isLeft)
@@ -23,7 +23,7 @@ class RuntimeSpec extends UnitSpec {
 
   "A Matcher[V] constraint" should "return Right if the argument matches the given V regex" in {
 
-    def dummy(x: String / Match["^[a-z0-9]+"]): String / Match["^[a-z0-9]+"] = x
+    def dummy(x: String / RuntimeOnly[Match["^[a-z0-9]+"]]): String / RuntimeOnly[Match["^[a-z0-9]+"]] = x
 
     assert(dummy("abc123").isRight)
     assert(dummy("abc").isRight)


### PR DESCRIPTION
This PR introduces compile time checking for `LowerCase`, `UpperCase` and `Match`.

Because `inline given [V] SomeClassThatRequiresV[V]` is not really inlined in compile time - from my understanding it must be generated for given V so I guess that breaks inlining - to get compile time checking for Match, `inline given MatchConstraint[CustomMatch] with {}` must be declared.