### PR TITLE
cats: add refineEither* methods

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -55,6 +55,17 @@ object main extends ScalaModule with ScalafmtModule with CiReleaseModule {
 
 object examples extends Module {
 
+  object catsValidation extends ScalaModule with ScalafmtModule {
+
+    def scalaVersion = main.scalaVersion
+
+    def moduleDeps = Seq(main, cats)
+
+    def ivyDeps = Agg(
+      ivy"org.typelevel::cats-effect:3.4.2"
+    )
+  }
+
   object formCats extends ScalaModule with ScalafmtModule {
 
     def scalaVersion = main.scalaVersion

--- a/cats/src/io/github/iltotore/iron/cats.scala
+++ b/cats/src/io/github/iltotore/iron/cats.scala
@@ -1,8 +1,21 @@
 package io.github.iltotore.iron
 
 import _root_.cats.{Eq, Monoid, Order, Semigroup, Show}
-import _root_.cats.data.{NonEmptyChain, NonEmptyList, Validated, ValidatedNec, ValidatedNel}
-import _root_.cats.kernel.{Band, BoundedSemilattice, CommutativeGroup, CommutativeMonoid, CommutativeSemigroup, Group, Hash, LowerBounded, PartialOrder, Semilattice, UpperBounded}
+import _root_.cats.data.{EitherNec, EitherNel, NonEmptyChain, NonEmptyList, Validated, ValidatedNec, ValidatedNel}
+import _root_.cats.kernel.{
+  Band,
+  BoundedSemilattice,
+  CommutativeGroup,
+  CommutativeMonoid,
+  CommutativeSemigroup,
+  Group,
+  Hash,
+  LowerBounded,
+  PartialOrder,
+  Semilattice,
+  UpperBounded
+}
+import _root_.cats.syntax.either.*
 import Validated.{Valid, Invalid}
 
 object cats:
@@ -14,11 +27,41 @@ object cats:
   extension [A](value: A)
 
     /**
+     * Refine the given value at runtime, resulting in an [[Either]].
+     *
+     * @param constraint the constraint to test with the value to refine.
+     * @return a [[Right]] containing this value as [[IronType]] or a [[Left]] containing the constraint message.
+     * @see [[refineNec]], [[refineNel]].
+     */
+    inline def refineEither[B](using inline constraint: Constraint[A, B]): Either[String, A :| B] =
+      Either.cond(constraint.test(value), value.asInstanceOf[A :| B], constraint.message)
+
+    /**
+     * Refine the given value at runtime, resulting in an [[EitherNec]].
+     *
+     * @param constraint the constraint to test with the value to refine.
+     * @return a [[Right]] containing this value as [[IronType]] or a [[Left]] containing the constraint message.
+     * @see [[refineEither]], [[refineNel]].
+     */
+    inline def refineNec[B](using inline constraint: Constraint[A, B]): EitherNec[String, A :| B] =
+      refineEither[B].toEitherNec
+
+    /**
+     * Refine the given value at runtime, resulting in an [[EitherNel]].
+     *
+     * @param constraint the constraint to test with the value to refine.
+     * @return a [[Right]] containing this value as [[IronType]] or a [[Left]] containing the constraint message.
+     * @see [[refineEither]], [[refineNec]].
+     */
+    inline def refineNel[B](using inline constraint: Constraint[A, B]): EitherNel[String, A :| B] =
+      refineEither[B].toEitherNel
+
+    /**
      * Refine the given value at runtime, resulting in a [[Validated]].
      *
      * @param constraint the constraint to test with the value to refine.
      * @return a [[Valid]] containing this value as [[IronType]] or an [[Invalid]] containing the constraint message.
-     * @see [[refineNec]], [[refineNel]].
+     * @see [[refineValidatedNec]], [[refineValidatedNel]].
      */
     inline def refineValidated[B](using inline constraint: Constraint[A, B]): Validated[String, A :| B] =
       Validated.cond(constraint.test(value), value.asInstanceOf[A :| B], constraint.message)
@@ -28,9 +71,9 @@ object cats:
      *
      * @param constraint the constraint to test with the value to refine.
      * @return a [[Valid]] containing this value as [[IronType]] or an [[Invalid]] containing a [[NonEmptyChain]] of error messages.
-     * @see [[refineValidated]], [[refineNel]].
+     * @see [[refineValidated]], [[refineValidatedNel]].
      */
-    inline def refineNec[B](using inline constraint: Constraint[A, B]): ValidatedNec[String, A :| B] =
+    inline def refineValidatedNec[B](using inline constraint: Constraint[A, B]): ValidatedNec[String, A :| B] =
       Validated.condNec(constraint.test(value), value.asInstanceOf[A :| B], constraint.message)
 
     /**
@@ -38,9 +81,9 @@ object cats:
      *
      * @param constraint the constraint to test with the value to refine.
      * @return a [[Valid]] containing this value as [[IronType]] or an [[Invalid]] containing a [[NonEmptyList]] of error messages.
-     * @see [[refineValidated]], [[refineNec]].
+     * @see [[refineValidated]], [[refineValidatedNec]].
      */
-    inline def refineNel[B](using inline constraint: Constraint[A, B]): ValidatedNel[String, A :| B] =
+    inline def refineValidatedNel[B](using inline constraint: Constraint[A, B]): ValidatedNel[String, A :| B] =
       Validated.condNel(constraint.test(value), value.asInstanceOf[A :| B], constraint.message)
 
 private object IronCatsInstances:

--- a/cats/src/io/github/iltotore/iron/cats.scala
+++ b/cats/src/io/github/iltotore/iron/cats.scala
@@ -27,16 +27,6 @@ object cats:
   extension [A](value: A)
 
     /**
-     * Refine the given value at runtime, resulting in an [[Either]].
-     *
-     * @param constraint the constraint to test with the value to refine.
-     * @return a [[Right]] containing this value as [[IronType]] or a [[Left]] containing the constraint message.
-     * @see [[refineNec]], [[refineNel]].
-     */
-    inline def refineEither[B](using inline constraint: Constraint[A, B]): Either[String, A :| B] =
-      Either.cond(constraint.test(value), value.asInstanceOf[A :| B], constraint.message)
-
-    /**
      * Refine the given value at runtime, resulting in an [[EitherNec]].
      *
      * @param constraint the constraint to test with the value to refine.
@@ -44,7 +34,7 @@ object cats:
      * @see [[refineEither]], [[refineNel]].
      */
     inline def refineNec[B](using inline constraint: Constraint[A, B]): EitherNec[String, A :| B] =
-      refineEither[B].toEitherNec
+      value.refineEither[B].toEitherNec
 
     /**
      * Refine the given value at runtime, resulting in an [[EitherNel]].
@@ -54,7 +44,7 @@ object cats:
      * @see [[refineEither]], [[refineNec]].
      */
     inline def refineNel[B](using inline constraint: Constraint[A, B]): EitherNel[String, A :| B] =
-      refineEither[B].toEitherNel
+      value.refineEither[B].toEitherNel
 
     /**
      * Refine the given value at runtime, resulting in a [[Validated]].

--- a/examples/catsValidation/src/io/github/iltotore/iron/catsValidation/Main.scala
+++ b/examples/catsValidation/src/io/github/iltotore/iron/catsValidation/Main.scala
@@ -1,0 +1,33 @@
+package io.github.iltotore.iron.catsValidation
+
+import cats.data.EitherNel
+import cats.effect.{IO, IOApp}
+import cats.syntax.all.*
+import io.github.iltotore.iron.{given, *}
+import io.github.iltotore.iron.cats.*
+import io.github.iltotore.iron.constraint.numeric.given
+import io.github.iltotore.iron.constraint.numeric.Greater
+import io.github.iltotore.iron.constraint.string.given
+import io.github.iltotore.iron.constraint.string.Contain
+
+object Main extends IOApp.Simple:
+
+  case class Person(
+      name: String :| Contain["a"],
+      surname: String :| Contain["z"],
+      age: Int :| Greater[0]
+  )
+
+  def program(
+      name: String,
+      surname: String,
+      age: Int
+  ): EitherNel[String, Person] =
+    (
+      name.refineNel[Contain["a"]],
+      surname.refineNel[Contain["z"]],
+      age.refineNel[Greater[0]]
+    ).parMapN(Person.apply)
+
+  val run: IO[Unit] =
+    program("foo", "bar", 0).fold(e => IO.println(s"ERROR: ${e.show}"), IO.println)

--- a/examples/catsValidation/src/io/github/iltotore/iron/catsValidation/README.md
+++ b/examples/catsValidation/src/io/github/iltotore/iron/catsValidation/README.md
@@ -1,0 +1,13 @@
+# Minimalist validatino using Iron and Cats
+
+Simple example of validation via `refineNel` (Iron) and `parMapN` (Cats).
+
+## Run the example
+
+Use the following command to run the example:
+
+```sh
+mill examples.catsValidation.run
+```
+
+Note: this command must be run in the Iron root directory.

--- a/examples/formCats/src/io/github/iltotore/iron/formCats/HttpServer.scala
+++ b/examples/formCats/src/io/github/iltotore/iron/formCats/HttpServer.scala
@@ -11,8 +11,6 @@ import org.http4s.implicits.*
 import org.http4s.circe.CirceEntityEncoder.* //To Encode a Map as Json in Response
 import org.http4s.circe.DecodingFailures
 
-import Account.given //Account entity codec
-
 object HttpServer:
 
   /**

--- a/examples/formCats/src/io/github/iltotore/iron/formCats/Main.scala
+++ b/examples/formCats/src/io/github/iltotore/iron/formCats/Main.scala
@@ -1,6 +1,7 @@
 package io.github.iltotore.iron.formCats
 
-import cats.effect.{ExitCode, IO, IOApp}
+import cats.effect.{IO, Resource, ResourceApp}
+import cats.syntax.functor.*
 
 import com.comcast.ip4s.*
 
@@ -11,14 +12,13 @@ import org.http4s.*
 import org.http4s.dsl.io.*
 import org.http4s.implicits.*
 
-object Main extends IOApp:
+object Main extends ResourceApp.Forever:
 
-  override def run(args: List[String]): IO[ExitCode] =
+  override def run(args: List[String]): Resource[IO, Unit] =
     EmberServerBuilder
       .default[IO]
       .withHost(ipv4"127.0.0.1")
       .withPort(port"8080")
       .withHttpApp(HttpServer.service.orNotFound)
       .build
-      .use(_ => IO.never)
-      .as(ExitCode.Success)
+      .void


### PR DESCRIPTION
Most users have moved away from explicitly using `Validated` and its variants. Instead, most of us use `Either` and its variants `EitherNec` and `EitherNel` together with the `Parallel` methods such as `parMapN`, which uses `Validated` instances before transforming it back to `Either`. 

- renames `refineNec` -> `refineValidatedNec`
- renames `refineNel` -> `refineValidatedNel`
- adds `refineNec` returning `EitherNec`
- adds `refineNel` returning `EitherNel`
- adds `catsValidation` example to showcase `refineNel` and `parMapN`

I'd like to get your feedback before I update the documentation. I propose to promote the usage of `Either` in the docs.