### PR TITLE
Add module for `jsoniter-scala` json codecs

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -150,6 +150,23 @@ object examples extends Module {
     )
 
   }
+
+  object formJsoniter extends ScalaModule with ScalafmtModule {
+
+    def scalaVersion = versions.scala
+
+    def moduleDeps = Seq(main, jsoniter)
+
+    val jsoniterVersion = "2.19.1"
+
+    def ivyDeps = Agg(
+      ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:$jsoniterVersion",
+    )
+
+    def compileIvyDeps = Agg(
+      ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:$jsoniterVersion"
+    )
+  }
 }
 
 trait SubModule extends BaseModule {
@@ -204,4 +221,31 @@ object zioJson extends SubModule {
   )
 
   object js extends JSCrossModule
+}
+
+object jsoniter extends SubModule {
+
+  def artifactName = "iron-jsoniter"
+
+  val jsoniterVersion = "2.19.1"
+
+  private val jsoniterMacros = ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:$jsoniterVersion"
+
+  def ivyDeps = Agg(
+    ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core::$jsoniterVersion"
+  )
+
+  def compileIvyDeps = Agg(jsoniterMacros)
+
+  object js extends JSCrossModule {
+    def compileIvyDeps = Agg(jsoniterMacros)
+  }
+
+  object native extends NativeCrossModule {
+    def compileIvyDeps = Agg(jsoniterMacros)
+  }
+
+  object test extends Tests {
+    def compileIvyDeps = Agg(jsoniterMacros)
+  }
 }

--- a/examples/formJsoniter/src/io/github/iltotore/iron/formJsoniter/Account.scala
+++ b/examples/formJsoniter/src/io/github/iltotore/iron/formJsoniter/Account.scala
@@ -1,0 +1,43 @@
+package io.github.iltotore.iron.formJsoniter
+
+import com.github.plokhotnyuk.jsoniter_scala.core.*
+import com.github.plokhotnyuk.jsoniter_scala.macros.*
+import io.github.iltotore.iron.constraint.all.*
+import io.github.iltotore.iron.jsoniter.makeCodec
+import io.github.iltotore.iron.{*, given}
+
+import scala.util.Try
+
+type Username = (Alphanumeric & MinLength[3] & MaxLength[10]) DescribedAs
+  "Username should be alphanumeric and have a length between 3 and 10"
+
+type Password = (Match["[A-Za-z].*[0-9]|[0-9].*[A-Za-z]"] & MinLength[6] & MaxLength[20]) DescribedAs
+  "Password must contain atleast a letter, a digit and have a length between 6 and 20"
+
+type Age = Greater[0] DescribedAs "Age should be strictly positive"
+
+/**
+ * A basic Account with a name, a password and an age.
+ *
+ * @param name an alphanumeric String with a length between 3 and 10.
+ * @param password an String containing atleast a letter, a digit, with a length between 6 and 20.
+ * @param age a strictly positive Int.
+ */
+case class Account(name: String :| Username, password: String :| Password, age: Int :| Age)
+
+object Account:
+  // Create codecs for the underlying types since the automatic derivation doesn't work when the types are within case classes.
+  // These need to be named (see: https://github.com/plokhotnyuk/jsoniter-scala#known-issues)
+  given usrCodec: JsonValueCodec[String :| Username] = makeCodec
+  given passCodec: JsonValueCodec[String :| Password] = makeCodec
+  given ageCodec: JsonValueCodec[Int :| Age] = makeCodec
+
+  given JsonValueCodec[Account] = JsonCodecMaker.make
+
+  private val readerConfig = ReaderConfig.withAppendHexDumpToParseException(false)
+
+  def fromJsonString(jsonString: String): Either[String, Account] =
+    Try(readFromString[Account](jsonString, readerConfig)).toEither.left.map(_.getMessage)
+
+  extension (account: Account)
+    def asJsonString: String = writeToString(account)

--- a/examples/formJsoniter/src/io/github/iltotore/iron/formJsoniter/main.scala
+++ b/examples/formJsoniter/src/io/github/iltotore/iron/formJsoniter/main.scala
@@ -1,0 +1,22 @@
+package io.github.iltotore.iron.formJsoniter
+
+private val validJson =
+  """{
+    |  "name": "foo",
+    |  "password": "bar123",
+    |  "age": 42
+    |}""".stripMargin
+
+private val invalidJson =
+  """{
+    |  "name": "foo",
+    |  "password": "bar",
+    |  "age": 42
+    |}""".stripMargin
+
+@main def main: Unit =
+  assert(Account.fromJsonString(invalidJson).isLeft)
+  println(Account.fromJsonString(invalidJson))
+  val account = Account.fromJsonString(validJson) // Right(Account("foo", "bar123", 42)
+  val jsonString = account.map(_.asJsonString).getOrElse("")
+  assert(jsonString == validJson.replace("\n", "").replace(" ", ""))

--- a/jsoniter/src/io/github/iltotore/iron/jsoniter.scala
+++ b/jsoniter/src/io/github/iltotore/iron/jsoniter.scala
@@ -12,6 +12,9 @@ object jsoniter:
    */
   inline given makeCodec[A, B](using inline constraint: Constraint[A, B]): JsonValueCodec[A :| B] = new:
     private val codec = JsonCodecMaker.make[A]
-    def decodeValue(in: JsonReader, default: A :| B): A :| B = codec.decodeValue(in, default).refineEither[B].fold(in.decodeError, identity)
+    def decodeValue(in: JsonReader, default: A :| B): A :| B =
+      val decoded = codec.decodeValue(in, default)
+      if constraint.test(decoded) then decoded.asInstanceOf[A :| B]
+      else in.decodeError(constraint.message)
     def encodeValue(x: A :| B, out: JsonWriter): Unit = codec.encodeValue(x, out)
     def nullValue: A :| B = null.asInstanceOf[A :| B]

--- a/jsoniter/src/io/github/iltotore/iron/jsoniter.scala
+++ b/jsoniter/src/io/github/iltotore/iron/jsoniter.scala
@@ -1,0 +1,17 @@
+package io.github.iltotore.iron
+
+import com.github.plokhotnyuk.jsoniter_scala.core.*
+import com.github.plokhotnyuk.jsoniter_scala.macros.*
+
+object jsoniter:
+
+  /**
+   * Creates a [[JsonValueCodec]] for refined types
+   *
+   * @param constraint the [[Constraint]] implementation to test the decoded value.
+   */
+  inline given makeCodec[A, B](using inline constraint: Constraint[A, B]): JsonValueCodec[A :| B] = new:
+    private val codec = JsonCodecMaker.make[A]
+    def decodeValue(in: JsonReader, default: A :| B): A :| B = codec.decodeValue(in, default).refineEither[B].fold(in.decodeError, identity)
+    def encodeValue(x: A :| B, out: JsonWriter): Unit = codec.encodeValue(x, out)
+    def nullValue: A :| B = null.asInstanceOf[A :| B]

--- a/jsoniter/test/src/io/github/iltotore/iron/JsoniterSuite.scala
+++ b/jsoniter/test/src/io/github/iltotore/iron/JsoniterSuite.scala
@@ -1,0 +1,44 @@
+package io.github.iltotore.iron
+
+import com.github.plokhotnyuk.jsoniter_scala.core.{JsonValueCodec, readFromString, writeToString}
+import com.github.plokhotnyuk.jsoniter_scala.macros.*
+import io.github.iltotore.iron.{*, given}
+import io.github.iltotore.iron.jsoniter.given
+import io.github.iltotore.iron.constraint.all.{*, given}
+import utest.{Show as _, *}
+
+import scala.runtime.stdLibPatches.Predef.assert
+import scala.util.Try
+
+object JsoniterSuite extends TestSuite:
+  type Zero = StrictEqual[0]
+  val zero: Int :| Zero = 0
+
+  case class Number(zero: Int :| Zero)
+
+  given JsonValueCodec[Zero] = JsonCodecMaker.make
+  given JsonValueCodec[Number] = JsonCodecMaker.make
+
+  extension [A](value: A)(using JsonValueCodec[A])
+    def assertEncoding(expected: String): Unit = assert(writeToString(value) == expected)
+
+  extension (value: String)
+    def assertDecodingSuccess[A](expected: A)(using JsonValueCodec[A]): Unit = assert(Try(readFromString[A](value)).fold(_ => false, _ == expected))
+    def assertDecodingFailure[A](using JsonValueCodec[A]): Unit = assert(Try(readFromString[A](value)).isFailure)
+
+  val tests: Tests = Tests {
+    test("encoding") {
+      test - zero.assertEncoding("0")
+      test - Number(0).assertEncoding("""{"zero":0}""")
+    }
+
+    test("decoding - valid predicate") {
+      test - "0".assertDecodingSuccess[Int :| Zero](zero)
+      test - """{"zero":0}""".assertDecodingSuccess[Number](Number(0))
+    }
+
+    test("decoding - invalid predicate") {
+      test - "1".assertDecodingFailure[Zero]
+      test - """{"zero":1}""".assertDecodingFailure[Number]
+    }
+  }


### PR DESCRIPTION
Implements the feature requested in #82.

In this implementation, we're generating the codec for the underlying type within the `given` / method itself. This is only possible since the method is inlined, so type `A` is actually known when we create the codec. The implementation is largely based off the approach recommended by the library: https://github.com/plokhotnyuk/jsoniter-scala/blob/7da4af1c45e11f3877708ab6d394dad9f92a3766/jsoniter-scala-macros/shared/src/test/scala-3/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodeMakerNewTypeSpec.scala#L16-L45

One potential improvement to this is to add another method that accepts `CodecMakerConfig` but I wanted to keep it simple for the time being.

I've also included a basic example on how the jsoniter module can be used to create Jsoniter codecs for iron types in the `/examples` module. To avoid repeating the full code from `/formCats` or `/formZio`, the example shows only how to create the codec and use it to encode / decode the `Account` case class. Another approach would have been to add it as an alternative json parser in `/formCats` - let me know what you think.
