### PR TITLE
Micro-optimizations for Length and Upper/Lowercase constraints

### DIFF
--- a/main/src/io/github/iltotore/iron/constraint/collection.scala
+++ b/main/src/io/github/iltotore/iron/constraint/collection.scala
@@ -38,7 +38,7 @@ object collection:
   object MinLength:
     inline given [V <: Int, I <: Iterable[?]]: Constraint[I, MinLength[V]] with
 
-      override inline def test(value: I): Boolean = value.size >= constValue[V]
+      override inline def test(value: I): Boolean = value.sizeCompare(constValue[V]) >= 0
 
       override inline def message: String = "Should contain atleast " + stringValue[V] + " elements"
 
@@ -56,7 +56,7 @@ object collection:
   object MaxLength:
     inline given [V <: Int, I <: Iterable[?]]: Constraint[I, MaxLength[V]] with
 
-      override inline def test(value: I): Boolean = value.size <= constValue[V]
+      override inline def test(value: I): Boolean = value.sizeCompare(constValue[V]) <= 0
 
       override inline def message: String = "Should contain at most " + stringValue[V] + " elements"
 

--- a/main/src/io/github/iltotore/iron/constraint/string.scala
+++ b/main/src/io/github/iltotore/iron/constraint/string.scala
@@ -63,8 +63,8 @@ object string:
 
     def checkLowerCase(valueExpr: Expr[String])(using Quotes): Expr[Boolean] =
       valueExpr.value match
-        case Some(value) => Expr(value.forall(_.isLower))
-        case None        => '{ $valueExpr.forall(_.isLower) }
+        case Some(value) => Expr(value.forall(v => !v.isLetter || v.isLower))
+        case None        => '{ $valueExpr.forall(v => !v.isLetter || v.isLower) }
 
   object UpperCase:
     inline given Constraint[String, UpperCase] with
@@ -75,8 +75,8 @@ object string:
 
     private def checkUpperCase(valueExpr: Expr[String])(using Quotes): Expr[Boolean] =
       valueExpr.value match
-        case Some(value) => Expr(value.forall(_.isUpper))
-        case None        => '{ $valueExpr.forall(_.isUpper) }
+        case Some(value) => Expr(value.forall(v => !v.isLetter || v.isUpper))
+        case None        => '{ $valueExpr.forall(v => !v.isLetter || v.isUpper) }
 
   object Match:
     inline given [V <: String]: Constraint[String, Match[V]] with

--- a/main/src/io/github/iltotore/iron/constraint/string.scala
+++ b/main/src/io/github/iltotore/iron/constraint/string.scala
@@ -63,8 +63,8 @@ object string:
 
     def checkLowerCase(valueExpr: Expr[String])(using Quotes): Expr[Boolean] =
       valueExpr.value match
-        case Some(value) => Expr(value equals value.toLowerCase)
-        case None        => '{ $valueExpr equals $valueExpr.toLowerCase }
+        case Some(value) => Expr(value.forall(_.isLower))
+        case None        => '{ $valueExpr.forall(_.isLower) }
 
   object UpperCase:
     inline given Constraint[String, UpperCase] with
@@ -75,8 +75,8 @@ object string:
 
     private def checkUpperCase(valueExpr: Expr[String])(using Quotes): Expr[Boolean] =
       valueExpr.value match
-        case Some(value) => Expr(value equals value.toUpperCase)
-        case None        => '{ $valueExpr equals $valueExpr.toUpperCase }
+        case Some(value) => Expr(value.forall(_.isUpper))
+        case None        => '{ $valueExpr.forall(_.isUpper) }
 
   object Match:
     inline given [V <: String]: Constraint[String, Match[V]] with

--- a/main/test/src/io/github/iltotore/iron/testing/StringSuite.scala
+++ b/main/test/src/io/github/iltotore/iron/testing/StringSuite.scala
@@ -24,13 +24,13 @@ object StringSuite extends TestSuite:
     }
 
     test("lowercase") {
-      test - "abc".assertRefine[LowerCase]
-      test - "ABC".assertNotRefine[LowerCase]
+      test - "abc 123 \n".assertRefine[LowerCase]
+      test - "ABC 123 \n".assertNotRefine[LowerCase]
     }
 
     test("uppercase") {
-      test - "abc".assertNotRefine[UpperCase]
-      test - "ABC".assertRefine[UpperCase]
+      test - "abc 123 \n".assertNotRefine[UpperCase]
+      test - "ABC 123 \n".assertRefine[UpperCase]
     }
 
     test("match") {


### PR DESCRIPTION
This PR contains some microoptimizations for the following constraints:

* `MinLength` / `MaxLength`: `.length` / `.size` during runtime is calculated by iterating over the entire collection. This can be avoided by using `.sizeCompare` which breaks the iteration once the RHS value has been reached
* `UpperCase` / `LowerCase`: Instead of converting the string and then comparing it, iterate over the characters and break if any of them is not upper/lowercase. This avoids the creation of the additional string object during runtime.

There is another issue with `.toLowerCase` and `.toUpperCase` which I believe that this PR also address by this change. On the JVM, these methods are locale-specific (see below). I'm not 100% sure whether the changes I introduced fix this, I'll need to look into it.

![image](https://user-images.githubusercontent.com/67301607/207727454-015086e7-73d2-4818-a34c-12fbd698524d.png)
 