### PR TITLE
feat: Add common char constraints

### DIFF
--- a/main/src/io/github/iltotore/iron/constraint/all.scala
+++ b/main/src/io/github/iltotore/iron/constraint/all.scala
@@ -2,6 +2,7 @@ package io.github.iltotore.iron.constraint
 
 object all:
   export any.*
+  export char.*
   export collection.*
   export numeric.*
   export string.*

--- a/main/src/io/github/iltotore/iron/constraint/char.scala
+++ b/main/src/io/github/iltotore/iron/constraint/char.scala
@@ -36,7 +36,7 @@ object char:
   /**
    * Tests if the input is neither a digit or a letter.
    */
-  type IsSpecial = Not[Digit] & Not[Letter]
+  type Special = Not[Digit] & Not[Letter]
 
   object Blank:
 

--- a/main/src/io/github/iltotore/iron/constraint/char.scala
+++ b/main/src/io/github/iltotore/iron/constraint/char.scala
@@ -11,7 +11,7 @@ object char:
   /**
    * Tests if the input is whitespace.
    */
-  final class Blank
+  final class Whitespace
 
   /**
    * Tests if the given input is lower-cased.
@@ -38,9 +38,9 @@ object char:
    */
   type Special = Not[Digit] & Not[Letter]
 
-  object Blank:
+  object Whitespace:
 
-    inline given Constraint[Char, Blank] with
+    inline given Constraint[Char, Whitespace] with
 
       override inline def test(value: Char): Boolean = ${ check('value) }
 

--- a/main/src/io/github/iltotore/iron/constraint/char.scala
+++ b/main/src/io/github/iltotore/iron/constraint/char.scala
@@ -1,0 +1,104 @@
+package io.github.iltotore.iron.constraint
+
+import io.github.iltotore.iron.Constraint
+import io.github.iltotore.iron.compileTime.*
+import io.github.iltotore.iron.constraint.any.Not
+
+import scala.quoted.*
+
+object char:
+
+  /**
+   * Tests if the input is whitespace.
+   */
+  final class Blank
+
+  /**
+   * Tests if the given input is lower-cased.
+   */
+  final class LowerCase
+
+  /**
+   * Tests if the input is upper-cased.
+   */
+  final class UpperCase
+
+  /**
+   * Tests if the input is a digit (from 0 to 9).
+   */
+  final class Digit
+
+  /**
+   * Tests if the input is a letter (from a to z, case insensitive).
+   */
+  final class Letter
+
+  /**
+   * Tests if the input is neither a digit or a letter.
+   */
+  type IsSpecial = Not[Digit] & Not[Letter]
+
+  object Blank:
+
+    inline given Constraint[Char, Blank] with
+
+      override inline def test(value: Char): Boolean = ${ check('value) }
+
+      override inline def message: String = "Should be a whitespace"
+
+    private def check(expr: Expr[Char])(using Quotes): Expr[Boolean] =
+      expr.value match
+        case Some(value) => Expr(value.isWhitespace)
+        case None        => '{ $expr.isWhitespace }
+
+  object LowerCase:
+
+    inline given Constraint[Char, LowerCase] with
+
+      override inline def test(value: Char): Boolean = ${ check('value) }
+
+      override inline def message: String = "Should be a lower cased"
+
+    private def check(expr: Expr[Char])(using Quotes): Expr[Boolean] =
+      expr.value match
+        case Some(value) => Expr(value.isLower)
+        case None        => '{ $expr.isLower }
+
+  object UpperCase:
+
+    inline given Constraint[Char, UpperCase] with
+
+      override inline def test(value: Char): Boolean = ${ check('value) }
+
+      override inline def message: String = "Should be a upper cased"
+
+    private def check(expr: Expr[Char])(using Quotes): Expr[Boolean] =
+      expr.value match
+        case Some(value) => Expr(value.isUpper)
+        case None        => '{ $expr.isUpper }
+
+  object Digit:
+
+    inline given Constraint[Char, Digit] with
+
+      override inline def test(value: Char): Boolean = ${ check('value) }
+
+      override inline def message: String = "Should be a digit"
+
+    private def check(expr: Expr[Char])(using Quotes): Expr[Boolean] =
+      expr.value match
+        case Some(value) => Expr(value.isDigit)
+        case None        => '{ $expr.isDigit }
+
+  object Letter:
+
+    inline given Constraint[Char, Letter] with
+
+      override inline def test(value: Char): Boolean = ${ check('value) }
+
+      override inline def message: String = "Should be a letter"
+
+    private def check(expr: Expr[Char])(using Quotes): Expr[Boolean] =
+      expr.value match
+        case Some(value) => Expr(value.isLetter)
+        case None        => '{ $expr.isLetter }

--- a/main/src/io/github/iltotore/iron/constraint/collection.scala
+++ b/main/src/io/github/iltotore/iron/constraint/collection.scala
@@ -101,7 +101,7 @@ object collection:
 
       override inline def test(value: I): Boolean = value.forall(summonInline[Impl].test(_))
 
-      override inline def message: String = "For each element: (" + summonInline[Impl] + ")"
+      override inline def message: String = "For each element: (" + summonInline[Impl].message + ")"
 
     inline given [A, I <: Iterable[A], C, Impl <: Constraint[A, C]](using inline impl: Impl): ForAllIterable[A, I, C, Impl] =
       new ForAllIterable

--- a/main/src/io/github/iltotore/iron/constraint/collection.scala
+++ b/main/src/io/github/iltotore/iron/constraint/collection.scala
@@ -1,6 +1,6 @@
 package io.github.iltotore.iron.constraint
 
-import io.github.iltotore.iron.Constraint
+import io.github.iltotore.iron.{:|, ==>, Constraint, Implication}
 import io.github.iltotore.iron.compileTime.*
 
 import scala.compiletime.{constValue, summonInline}

--- a/main/src/io/github/iltotore/iron/constraint/string.scala
+++ b/main/src/io/github/iltotore/iron/constraint/string.scala
@@ -4,7 +4,7 @@ import io.github.iltotore.iron.Constraint
 import io.github.iltotore.iron.constraint.any.*
 import io.github.iltotore.iron.constraint.collection.*
 import io.github.iltotore.iron.compileTime.*
-import io.github.iltotore.iron.constraint.char.{Digit, Letter, LowerCase, UpperCase}
+import io.github.iltotore.iron.constraint.char.{Digit, Letter, LowerCase, UpperCase, Whitespace}
 
 import scala.compiletime.constValue
 import scala.quoted.*
@@ -17,12 +17,17 @@ import scala.quoted.*
 object string:
 
   /**
-   * Tests if all characters of the input are lower cased.
+   * Tests if the input only contains whitespaces.
+   */
+  type Blank = ForAll[Whitespace] DescribedAs "Should only contain whitespaces"
+
+  /**
+   * Tests if all letters of the input are lower cased.
    */
   type LettersLowerCase = ForAll[Not[Letter] | LowerCase] DescribedAs "All letters should be lower cased"
 
   /**
-   * Tests if all characters of the input are upper cased.
+   * Tests if all letters of the input are upper cased.
    */
   type LettersUpperCase = ForAll[Not[Letter] | UpperCase] DescribedAs "All letters should be upper cased"
 

--- a/main/src/io/github/iltotore/iron/constraint/string.scala
+++ b/main/src/io/github/iltotore/iron/constraint/string.scala
@@ -4,6 +4,8 @@ import io.github.iltotore.iron.Constraint
 import io.github.iltotore.iron.constraint.any.*
 import io.github.iltotore.iron.constraint.collection.*
 import io.github.iltotore.iron.compileTime.*
+import io.github.iltotore.iron.constraint.char.{Digit, Letter, LowerCase, UpperCase}
+
 import scala.compiletime.constValue
 import scala.quoted.*
 
@@ -15,16 +17,26 @@ import scala.quoted.*
 object string:
 
   /**
+   * Tests if all characters of the input are lower cased.
+   */
+  type LettersLowerCase = ForAll[Not[Letter] | LowerCase] DescribedAs "All letters should be lower cased"
+
+  /**
+   * Tests if all characters of the input are upper cased.
+   */
+  type LettersUpperCase = ForAll[Not[Letter] | UpperCase] DescribedAs "All letters should be upper cased"
+
+  /**
+   * Tests if the input only contains alphanumeric characters.
+   */
+  type Alphanumeric = ForAll[Digit | Letter] DescribedAs "Should be alphanumeric"
+
+  /**
    * Tests if the input matches the given regex.
    *
    * @tparam V the pattern to match against the input.
    */
   final class Match[V <: String]
-
-  /**
-   * Tests if the input only contains alphanumeric characters.
-   */
-  type Alphanumeric = Match["^[a-zA-Z0-9]+"] DescribedAs "Should be alphanumeric"
 
   /**
    * Tests if the input is a valid URL.

--- a/main/src/io/github/iltotore/iron/constraint/string.scala
+++ b/main/src/io/github/iltotore/iron/constraint/string.scala
@@ -13,15 +13,6 @@ import scala.quoted.*
  * @see [[collection]]
  */
 object string:
-  /**
-   * Tests if the given input is lower-cased.
-   */
-  final class LowerCase
-
-  /**
-   * Tests if the input is upper-cased.
-   */
-  final class UpperCase
 
   /**
    * Tests if the input matches the given regex.
@@ -51,35 +42,6 @@ object string:
   type UUIDLike =
     Match["^([0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12})"] DescribedAs "Should be an UUID"
 
-  /**
-   * Tests if the input is empty or contains whitespace characters only
-   */
-  final class Blank
-
-  object LowerCase:
-    inline given Constraint[String, LowerCase] with
-
-      override inline def test(value: String): Boolean = ${ check('value) }
-
-      override inline def message: String = "Should be lower cased"
-
-    private def check(valueExpr: Expr[String])(using Quotes): Expr[Boolean] =
-      valueExpr.value match
-        case Some(value) => Expr(value.forall(v => !v.isLetter || v.isLower))
-        case None        => '{ $valueExpr.forall(v => !v.isLetter || v.isLower) }
-
-  object UpperCase:
-    inline given Constraint[String, UpperCase] with
-
-      override inline def test(value: String): Boolean = ${ check('value) }
-
-      override inline def message: String = "Should be upper cased"
-
-    private def check(valueExpr: Expr[String])(using Quotes): Expr[Boolean] =
-      valueExpr.value match
-        case Some(value) => Expr(value.forall(v => !v.isLetter || v.isUpper))
-        case None        => '{ $valueExpr.forall(v => !v.isLetter || v.isUpper) }
-
   object Match:
     inline given [V <: String]: Constraint[String, Match[V]] with
 
@@ -91,15 +53,3 @@ object string:
       (valueExpr.value, regexExpr.value) match
         case (Some(value), Some(regex)) => Expr(value.matches(regex))
         case _                          => '{ $valueExpr.matches($regexExpr) }
-
-  object Blank:
-    inline given Constraint[String, Blank] with
-
-      override inline def test(value: String): Boolean = ${ check('value) }
-
-      override inline def message: String = "Should be empty or contain only whitespace characters"
-
-    private def check(valueExpr: Expr[String])(using Quotes): Expr[Boolean] =
-      valueExpr.value match
-        case Some(value) => Expr(value.forall(_.isWhitespace))
-        case _           => '{ $valueExpr.forall(_.isWhitespace) }

--- a/main/src/io/github/iltotore/iron/conversion.scala
+++ b/main/src/io/github/iltotore/iron/conversion.scala
@@ -1,5 +1,7 @@
 package io.github.iltotore.iron
 
+import io.github.iltotore.iron.constraint.collection.ForAll
+
 import scala.language.implicitConversions
 
 /**
@@ -22,10 +24,38 @@ implicit inline def autoRefine[A, C](inline value: A)(using inline constraint: C
  * Implicitly cast a constrained value to another if verified.
  *
  * @param value the refined to value to cast.
- * @param Implication the evidence that the original constraint `C1` implies `C2`.
+ * @param `C1 ==> C2` the evidence that the original constraint `C1` implies `C2`.
  * @tparam A the refined type.
  * @tparam C1 the original constraint.
  * @tparam C2 the target constraint.
  * @return the given value constrained by `C2`.
  */
 implicit inline def autoCastIron[A, C1, C2](inline value: A :| C1)(using C1 ==> C2): A :| C2 = value.asInstanceOf
+
+/**
+ * Implicitly cast an iterable of elements constrained by `C1` into an iterable constrained by `ForAll[C2]` if `C1` implies `C2`.
+ * @param iterable the iterable to factorize.
+ * @param `C1 ==> C2` the evidence that `C1` implies `C2`.
+ * @tparam A the refined type.
+ * @tparam I the iterable type.
+ * @tparam C1 the original constraint.
+ * @tparam C2 the target constraint.
+ * @return the given value as instance of `I[A] :| ForAll[C2]`.
+ * @see [[autoDistribute]]
+ */
+implicit inline def autoFactorize[A, I[_] <: Iterable[_], C1, C2](inline iterable: I[A :| C1])(using C1 ==> C2): I[A] :| ForAll[C2] =
+  iterable.asInstanceOf
+
+/**
+ * Implicitly cast an iterable constrained by `ForAll[C1]` into an iterable of elements constrained by `C2` if `C1` implies `C2`.
+ * @param iterable the iterable to factorize.
+ * @param `C1 ==> C2` the evidence that `C1` implies `C2`.
+ * @tparam A the refined type.
+ * @tparam I the iterable type.
+ * @tparam C1 the original constraint.
+ * @tparam C2 the target constraint.
+ * @return the given value as instance of `I[A :| C2]`.
+ * @see [[autoFactorize]]
+ */
+implicit inline def autoDistribute[A, I[_] <: Iterable[_], C1, C2](inline iterable: I[A] :| ForAll[C1])(using C1 ==> C2): I[A :| C2] =
+  iterable.asInstanceOf

--- a/main/test/src/io/github/iltotore/iron/testing/CharSuite.scala
+++ b/main/test/src/io/github/iltotore/iron/testing/CharSuite.scala
@@ -1,0 +1,60 @@
+package io.github.iltotore.iron.testing
+
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.all.*
+import utest.*
+
+object CharSuite extends TestSuite:
+
+  val tests: Tests = Tests {
+
+    test("blank") { //See https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Character.html#isWhitespace(char)
+      test - ' '.assertRefine[Blank]
+      test - '\t'.assertRefine[Blank]
+      test - '\n'.assertRefine[Blank]
+      test - '\u000B'.assertRefine[Blank]
+      test - '\f'.assertRefine[Blank]
+      test - '\r'.assertRefine[Blank]
+      test - '\u001C'.assertRefine[Blank]
+      test - '\u001D'.assertRefine[Blank]
+      test - '\u001E'.assertRefine[Blank]
+      test - '\u001F'.assertRefine[Blank]
+      test - 'a'.assertNotRefine[Blank]
+    }
+
+    test("lowercase") {
+      test - 'a'.assertRefine[LowerCase]
+      test - 'A'.assertNotRefine[LowerCase]
+      test - ' '.assertNotRefine[LowerCase]
+      test - '1'.assertNotRefine[LowerCase]
+    }
+
+    test("uppercase") {
+      test - 'A'.assertRefine[UpperCase]
+      test - 'a'.assertNotRefine[UpperCase]
+      test - ' '.assertNotRefine[UpperCase]
+      test - '1'.assertNotRefine[UpperCase]
+    }
+
+    test("digit") {
+      test - '1'.assertRefine[Digit]
+      test - 'a'.assertNotRefine[Digit]
+      test - 'A'.assertNotRefine[Digit]
+      test - '-'.assertNotRefine[Digit]
+    }
+
+    test("letter") {
+      test - 'a'.assertRefine[Letter]
+      test - 'A'.assertRefine[Letter]
+      test - '1'.assertNotRefine[Letter]
+      test - '-'.assertNotRefine[Letter]
+    }
+
+    test("special") {
+      test - ' '.assertRefine[IsSpecial]
+      test - '%'.assertRefine[IsSpecial]
+      test - 'a'.assertNotRefine[IsSpecial]
+      test - 'A'.assertNotRefine[IsSpecial]
+      test - '1'.assertNotRefine[IsSpecial]
+    }
+  }

--- a/main/test/src/io/github/iltotore/iron/testing/CharSuite.scala
+++ b/main/test/src/io/github/iltotore/iron/testing/CharSuite.scala
@@ -51,10 +51,10 @@ object CharSuite extends TestSuite:
     }
 
     test("special") {
-      test - ' '.assertRefine[IsSpecial]
-      test - '%'.assertRefine[IsSpecial]
-      test - 'a'.assertNotRefine[IsSpecial]
-      test - 'A'.assertNotRefine[IsSpecial]
-      test - '1'.assertNotRefine[IsSpecial]
+      test - ' '.assertRefine[Special]
+      test - '%'.assertRefine[Special]
+      test - 'a'.assertNotRefine[Special]
+      test - 'A'.assertNotRefine[Special]
+      test - '1'.assertNotRefine[Special]
     }
   }

--- a/main/test/src/io/github/iltotore/iron/testing/CharSuite.scala
+++ b/main/test/src/io/github/iltotore/iron/testing/CharSuite.scala
@@ -9,17 +9,17 @@ object CharSuite extends TestSuite:
   val tests: Tests = Tests {
 
     test("blank") { //See https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Character.html#isWhitespace(char)
-      test - ' '.assertRefine[Blank]
-      test - '\t'.assertRefine[Blank]
-      test - '\n'.assertRefine[Blank]
-      test - '\u000B'.assertRefine[Blank]
-      test - '\f'.assertRefine[Blank]
-      test - '\r'.assertRefine[Blank]
-      test - '\u001C'.assertRefine[Blank]
-      test - '\u001D'.assertRefine[Blank]
-      test - '\u001E'.assertRefine[Blank]
-      test - '\u001F'.assertRefine[Blank]
-      test - 'a'.assertNotRefine[Blank]
+      test - ' '.assertRefine[Whitespace]
+      test - '\t'.assertRefine[Whitespace]
+      test - '\n'.assertRefine[Whitespace]
+      test - '\u000B'.assertRefine[Whitespace]
+      test - '\f'.assertRefine[Whitespace]
+      test - '\r'.assertRefine[Whitespace]
+      test - '\u001C'.assertRefine[Whitespace]
+      test - '\u001D'.assertRefine[Whitespace]
+      test - '\u001E'.assertRefine[Whitespace]
+      test - '\u001F'.assertRefine[Whitespace]
+      test - 'a'.assertNotRefine[Whitespace]
     }
 
     test("lowercase") {

--- a/main/test/src/io/github/iltotore/iron/testing/CollectionSuite.scala
+++ b/main/test/src/io/github/iltotore/iron/testing/CollectionSuite.scala
@@ -6,6 +6,14 @@ import utest.*
 
 object CollectionSuite extends TestSuite:
 
+  final class IsA
+
+  given Constraint[Char, IsA] with
+
+    override inline def test(value: Char): Boolean = value == 'a'
+
+    override inline def message: String = "Should be 'a'"
+
   val tests: Tests = Tests {
 
     test("minLength") {
@@ -21,5 +29,20 @@ object CollectionSuite extends TestSuite:
     test("contains") {
       test - List(1, 2, 3).assertRefine[Contain[3]]
       test - List(1, 2, 4).assertNotRefine[Contain[3]]
+    }
+
+    test("forAll") {
+
+      test("iterable") {
+        test - Nil.assertRefine[ForAll[IsA]]
+        test - List('a', 'a', 'a').assertRefine[ForAll[IsA]]
+        test - List('a', 'b', 'c').assertNotRefine[ForAll[IsA]]
+      }
+
+      test("string") {
+        test - "".assertRefine[ForAll[IsA]]
+        test - "aaa".assertRefine[ForAll[IsA]]
+        test - "abc".assertNotRefine[ForAll[IsA]]
+      }
     }
   }

--- a/main/test/src/io/github/iltotore/iron/testing/StringSuite.scala
+++ b/main/test/src/io/github/iltotore/iron/testing/StringSuite.scala
@@ -24,13 +24,13 @@ object StringSuite extends TestSuite:
     }
 
     test("lowercase") {
-      test - "abc 123 \n".assertRefine[LowerCase]
-      test - "ABC 123 \n".assertNotRefine[LowerCase]
+      test - "abc 123 \n".assertRefine[LettersLowerCase]
+      test - "ABC 123 \n".assertNotRefine[LettersLowerCase]
     }
 
     test("uppercase") {
-      test - "abc 123 \n".assertNotRefine[UpperCase]
-      test - "ABC 123 \n".assertRefine[UpperCase]
+      test - "abc 123 \n".assertNotRefine[LettersUpperCase]
+      test - "ABC 123 \n".assertRefine[LettersUpperCase]
     }
 
     test("match") {
@@ -57,11 +57,4 @@ object StringSuite extends TestSuite:
       test - "http:///".assertNotRefine[URLLike]
     }
 
-    test("blank") {
-      test - "".assertRefine[Blank]
-      test - " ".assertRefine[Blank]
-      test - " \n \t ".assertRefine[Blank]
-      test - "foo ".assertNotRefine[Blank]
-      test - " foo".assertNotRefine[Blank]
-    }
   }


### PR DESCRIPTION
Related to #81.

This PR adds the following constraints:

- Char:
  - `Digit` using `Char#isDigit`
  - `Letter` using `Char#isLetter`
  - `Whitespace` using `Char#isWhitespace`
  - `Special` alias for `Not[Digit] & Not[Letter]`
- Collections:
  - `ForAll[C]`: tests if all elements satisfy the given constraint. Works at compile time for `String`.
- String:
  - `Blank` alias for `ForAll[Whitespace]`
  - `LettersLowerCase` alias for `ForAll[Not[Letter] | LowerCase]`. Replaces `LowerCase` for `String`.
  - `LettersUpperCase` alias for `ForAll[Not[Letter] | UpperCase]`. Replaces `UpperCase` for `String`.
  - `Alphanumeric` is now an alias for `ForAll[Digit | Letter]` instead of `Match["[0-9a-zA-Z]+"]`
 
Example of `ForAll`:

```scala
val digitCode: String :| ForAll[Digit] = "123" //OK
val invalid: String :| ForAll[Digit] = "123" //Error at compile time
```

Two new conversions are added to distribute/factorize `ForAll`:

```scala
val x: List[Int :| Greater[0]] = List(2, 2, 3)
val y: List[Int] :| ForAll[Greater[0]] = x
val z: List[Int :| Greater[0]] = y
```