### PR TITLE
feat: Add Scalacheck module

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ ___
 
 Iron is a lightweight library for refined types in Scala 3.
 
-It enables attaching constraints/assertions to types, to enforce properties and forbid invalid values. 
+It enables attaching constraints/assertions to types, to enforce properties and forbid invalid values.
 
 - **Catch bugs.** In the spirit of static typing, use more specific types to avoid invalid values.
-- **Compile-time and runtime.** Evaluate constraints at compile time, or explicitly check them at runtime (e.g. for a form).
+- **Compile-time and runtime.** Evaluate constraints at compile time, or explicitly check them at runtime (e.g. for a
+  form).
 - **Seamless.** Iron types are subtypes of their unrefined versions, meaning you can easily add or remove them.
-- **No black magic.** Use Scala 3's powerful inline, types and restricted macros for consistent behaviour and rules. No unexpected behaviour.
+- **No black magic.** Use Scala 3's powerful inline, types and restricted macros for consistent behaviour and rules. No
+  unexpected behaviour.
 - **Extendable.** Easily create your own constraints or integrations using classic typeclasses.
 
 To learn more about Iron, see the [microsite](https://iltotore.github.io/iron/docs/index.html).
@@ -55,20 +57,22 @@ ivy"io.github.iltotore::iron:version"
 
 ### Platform support
 
-| Module        | JVM | JS  | Native |
-|---------------|-----|-----|--------|
-| iron          | ✔️  | ✔️  | ✔️     |
-| iron-cats     | ✔️  | ✔️  | ✔️     |
-| iron-circe    | ✔️  | ✔️  | ✔️     |
-| iron-jsoniter | ✔️  | ✔️  | ✔️     | 
-| iron-zio      | ✔️  | ✔️  | ❌      |
-| iron-zio-json | ✔️  | ✔️  | ❌      |
+| Module          | JVM | JS  | Native |
+|-----------------|-----|-----|--------|
+| iron            | ✔️  | ✔️  | ✔️     |
+| iron-cats       | ✔️  | ✔️  | ✔️     |
+| iron-circe      | ✔️  | ✔️  | ✔️     |
+| iron-jsoniter   | ✔️  | ✔️  | ✔️     |
+| iron-scalacheck | ✔️  | ✔️  | ❌      |
+| iron-zio        | ✔️  | ✔️  | ❌      |
+| iron-zio-json   | ✔️  | ✔️  | ❌      |
 
 ## Adopters
 
 Here is a non-exhaustive list of projects using Iron.
 
-[Submit a PR](https://github.com/Iltotore/iron/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc) to add your project or company to the list.
+[Submit a PR](https://github.com/Iltotore/iron/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc) to add your project or
+company to the list.
 
 - [gvolpe/trading](https://github.com/gvolpe/trading/) ([book](https://leanpub.com/feda))
 

--- a/build.sc
+++ b/build.sc
@@ -73,7 +73,7 @@ object docs extends ScalaModule {
 
   def scalaVersion = versions.scala
 
-  val modules: Seq[ScalaModule] = Seq(main, cats, circe, jsoniter, zio, zioJson)
+  val modules: Seq[ScalaModule] = Seq(main, cats, circe, jsoniter, scalacheck, zio, zioJson)
 
   def docSources = T.sources {
     T.traverse(modules)(_.docSources)().flatten

--- a/build.sc
+++ b/build.sc
@@ -268,3 +268,16 @@ object jsoniter extends SubModule {
     def compileIvyDeps = Agg(jsoniterMacros)
   }
 }
+
+object scalacheck extends SubModule {
+
+  def artifactName = "iron-scalacheck"
+
+  def ivyDeps = Agg(
+    ivy"org.scalacheck::scalacheck:1.17.0"
+  )
+
+  object js extends JSCrossModule
+
+  object native extends NativeCrossModule
+}

--- a/build.sc
+++ b/build.sc
@@ -7,7 +7,7 @@ import scalalib._, scalalib.scalafmt._, scalalib.publish._, scalajslib._, scalan
 object versions {
   val scala = "3.2.1"
   val scalaJS = "1.12.0"
-  val scalaNative = "0.4.9"
+  val scalaNative = "0.4.10"
 }
 
 trait BaseModule extends ScalaModule with ScalafmtModule with CiReleaseModule { outer =>
@@ -26,7 +26,7 @@ trait BaseModule extends ScalaModule with ScalafmtModule with CiReleaseModule { 
       )
     )
 
-  trait Tests extends super.Tests {
+  trait Tests extends super.Tests with ScalafmtModule {
 
     def testFramework = "utest.runner.Framework"
 
@@ -274,10 +274,10 @@ object scalacheck extends SubModule {
   def artifactName = "iron-scalacheck"
 
   def ivyDeps = Agg(
-    ivy"org.scalacheck::scalacheck:1.17.0"
+    ivy"org.scalacheck::scalacheck::1.17.0"
   )
 
   object js extends JSCrossModule
 
-  object native extends NativeCrossModule
+  object test extends Tests
 }

--- a/docs/_docs/modules/index.md
+++ b/docs/_docs/modules/index.md
@@ -12,5 +12,6 @@ These modules are mostly "support"/"interoperability" modules to provide out of 
 - [Cats](cats.md): Typeclass instances and accumulative refinement methods.
 - [Circe](circe.md): Typeclass instances for refinement types.
 - [Jsoniter](jsoniter.md): Typeclass instances for refinement types.
+- [ScalaCheck](scalacheck.md): Typeclass instances for refinement types.
 - [ZIO](zio.md): Accumulative refinement method.
 - [ZIO-Json](zio-json.md): Typeclass instances for refinement types.

--- a/docs/_docs/modules/scalacheck.md
+++ b/docs/_docs/modules/scalacheck.md
@@ -1,0 +1,25 @@
+---
+title: "ScalaCheck Support"
+---
+
+# ScalaCheck Support
+
+This module provides `Arbitrary` instances for [ScalaCheck](https://scalacheck.org/).
+
+## Dependency
+
+SBT:
+
+```scala
+libraryDependencies += "io.github.iltotore" %% "iron-scalacheck" % "version"
+```
+
+Mill:
+
+```scala
+ivy"io.github.iltotore::iron-scalacheck:version"
+```
+
+## Arbitrary instances
+
+All refined types have a fallback `Arbitrary` instance. Some constraints have a custom instance which is usually faster and prevents exhaustion.

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -19,5 +19,6 @@ subsection:
       - page: modules/cats.md
       - page: modules/circe.md
       - page: modules/jsoniter.md
+      - page: modules/scalacheck.md
       - page: modules/zio.md
       - page: modules/zio-json.md

--- a/scalacheck/src/io/github/iltotore/iron/scalacheck/Adjacent.scala
+++ b/scalacheck/src/io/github/iltotore/iron/scalacheck/Adjacent.scala
@@ -1,0 +1,33 @@
+package io.github.iltotore.iron.scalacheck
+
+trait Adjacent[A]:
+
+  def nextUp(x: A): A
+
+  def nextDown(x: A): A
+
+object Adjacent:
+
+  given Adjacent[Int] with
+
+    override def nextUp(x: Int): Int = x + 1
+
+    override def nextDown(x: Int): Int = x - 1
+
+  given Adjacent[Long] with
+
+    override def nextUp(x: Long): Long = x + 1
+
+    override def nextDown(x: Long): Long = x - 1
+
+  given Adjacent[Float] with
+
+    override def nextUp(x: Float): Float = Math.nextUp(x)
+
+    override def nextDown(x: Float): Float = Math.nextDown(x)
+
+  given Adjacent[Double] with
+
+    override def nextUp(x: Double): Double = Math.nextUp(x)
+
+    override def nextDown(x: Double): Double = Math.nextDown(x)

--- a/scalacheck/src/io/github/iltotore/iron/scalacheck/Adjacent.scala
+++ b/scalacheck/src/io/github/iltotore/iron/scalacheck/Adjacent.scala
@@ -1,9 +1,23 @@
 package io.github.iltotore.iron.scalacheck
 
+/**
+ * Adjacent values for a type.
+ * @tparam A
+ */
 trait Adjacent[A]:
 
+  /**
+   * Get the next value.
+   * @param x the value to shift up.
+   * @return the least value greater than x.
+   */
   def nextUp(x: A): A
 
+  /**
+   * Get the down value.
+   * @param x the value to shift down.
+   * @return the greatest value lower than x.
+   */
   def nextDown(x: A): A
 
 object Adjacent:

--- a/scalacheck/src/io/github/iltotore/iron/scalacheck/Adjacent.scala
+++ b/scalacheck/src/io/github/iltotore/iron/scalacheck/Adjacent.scala
@@ -24,24 +24,24 @@ object Adjacent:
 
   given Adjacent[Int] with
 
-    override def nextUp(x: Int): Int = x + 1
+    override def nextUp(x: Int): Int = if x == Int.MaxValue then x else x + 1
 
-    override def nextDown(x: Int): Int = x - 1
+    override def nextDown(x: Int): Int = if x == Int.MinValue then x else x - 1
 
   given Adjacent[Long] with
 
-    override def nextUp(x: Long): Long = x + 1
+    override def nextUp(x: Long): Long = if x == Long.MaxValue then x else x + 1
 
-    override def nextDown(x: Long): Long = x - 1
+    override def nextDown(x: Long): Long = if x == Long.MinValue then x else x - 1
 
   given Adjacent[Float] with
 
-    override def nextUp(x: Float): Float = Math.nextUp(x)
+    override def nextUp(x: Float): Float = if x == Float.MaxValue then x else Math.nextUp(x)
 
-    override def nextDown(x: Float): Float = Math.nextDown(x)
+    override def nextDown(x: Float): Float = if x == Float.MinValue then x else Math.nextDown(x)
 
   given Adjacent[Double] with
 
-    override def nextUp(x: Double): Double = Math.nextUp(x)
+    override def nextUp(x: Double): Double = if x == Double.MaxValue then x else Math.nextUp(x)
 
     override def nextDown(x: Double): Double = Math.nextDown(x)

--- a/scalacheck/src/io/github/iltotore/iron/scalacheck/Max.scala
+++ b/scalacheck/src/io/github/iltotore/iron/scalacheck/Max.scala
@@ -8,7 +8,7 @@ object Max:
 
   def apply[A](x: A): Max[A] = new Max[A]:
 
-    def value: A = x
+    override def value: A = x
 
   given Max[Int] = Max(Int.MaxValue)
   given Max[Long] = Max(Long.MaxValue)

--- a/scalacheck/src/io/github/iltotore/iron/scalacheck/Max.scala
+++ b/scalacheck/src/io/github/iltotore/iron/scalacheck/Max.scala
@@ -1,0 +1,17 @@
+package io.github.iltotore.iron.scalacheck
+
+trait Max[A]:
+
+  def value: A
+
+object Max:
+
+  def apply[A](x: A): Max[A] = new Max[A]:
+
+    def value: A = x
+
+  given Max[Int] = Max(Int.MaxValue)
+  given Max[Long] = Max(Long.MaxValue)
+  given Max[Float] = Max(Float.MaxValue)
+  given Max[Double] = Max(Double.MaxValue)
+

--- a/scalacheck/src/io/github/iltotore/iron/scalacheck/Max.scala
+++ b/scalacheck/src/io/github/iltotore/iron/scalacheck/Max.scala
@@ -1,7 +1,14 @@
 package io.github.iltotore.iron.scalacheck
 
+/**
+ * Represent the maximum value of a type.
+ * @tparam A
+ */
 trait Max[A]:
 
+  /**
+   * The greatest value of type `A`
+   */
   def value: A
 
 object Max:

--- a/scalacheck/src/io/github/iltotore/iron/scalacheck/Min.scala
+++ b/scalacheck/src/io/github/iltotore/iron/scalacheck/Min.scala
@@ -1,7 +1,14 @@
 package io.github.iltotore.iron.scalacheck
 
+/**
+ * Represent the minimum value of a type.
+ * @tparam A
+ */
 trait Min[A]:
 
+  /**
+   * The lowest value of type `A`
+   */
   def value: A
 
 object Min:

--- a/scalacheck/src/io/github/iltotore/iron/scalacheck/Min.scala
+++ b/scalacheck/src/io/github/iltotore/iron/scalacheck/Min.scala
@@ -8,7 +8,7 @@ object Min:
 
   def apply[A](x: A): Min[A] = new Min[A]:
 
-    def value: A = x
+    override def value: A = x
 
   given Min[Int] = Min(Int.MinValue)
   given Min[Long] = Min(Long.MinValue)

--- a/scalacheck/src/io/github/iltotore/iron/scalacheck/Min.scala
+++ b/scalacheck/src/io/github/iltotore/iron/scalacheck/Min.scala
@@ -1,0 +1,17 @@
+package io.github.iltotore.iron.scalacheck
+
+trait Min[A]:
+
+  def value: A
+
+object Min:
+
+  def apply[A](x: A): Min[A] = new Min[A]:
+
+    def value: A = x
+
+  given Min[Int] = Min(Int.MinValue)
+  given Min[Long] = Min(Long.MinValue)
+  given Min[Float] = Min(Float.MinValue)
+  given Min[Double] = Min(Double.MinValue)
+

--- a/scalacheck/src/io/github/iltotore/iron/scalacheck/any.scala
+++ b/scalacheck/src/io/github/iltotore/iron/scalacheck/any.scala
@@ -1,0 +1,16 @@
+package io.github.iltotore.iron.scalacheck
+
+import io.github.iltotore.iron.*
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+
+object any extends LowPriorityArbitrary:
+
+  inline given [A, C1, C2](using C1 ==> C2, C2 ==> C1, Arbitrary[A :| C1]): Arbitrary[A :| C2] =
+    summon[Arbitrary[A :| C1]].asInstanceOf
+
+trait LowPriorityArbitrary:
+
+  inline given[A: Arbitrary, C](using inline constraint: Constraint[A, C]): Arbitrary[A :| C] =
+    Arbitrary(arbitrary.filter(constraint.test(_))).asInstanceOf

--- a/scalacheck/src/io/github/iltotore/iron/scalacheck/any.scala
+++ b/scalacheck/src/io/github/iltotore/iron/scalacheck/any.scala
@@ -2,6 +2,7 @@ package io.github.iltotore.iron.scalacheck
 
 import io.github.iltotore.iron.*
 import io.github.iltotore.iron.constraint.any.StrictEqual
+import io.github.iltotore.iron.macros.union.IsUnion
 import org.scalacheck.*
 import org.scalacheck.Arbitrary.arbitrary
 
@@ -9,12 +10,16 @@ import scala.compiletime.constValue
 
 object any extends LowPriorityArbitrary:
 
-  inline given [A, C1, C2](using C1 ==> C2, C2 ==> C1, Arbitrary[A :| C1]): Arbitrary[A :| C2] =
+  inline given strictEqual[A, V <: A]: Arbitrary[A :| StrictEqual[V]] = Arbitrary(Gen.oneOf(Seq(constValue[V]))).asInstanceOf
+  
+  inline given union[A, C](using IsUnion[C]): Arbitrary[A :| C] = Arbitrary(unionGen[A, C])
+
+trait LowPriorityArbitrary extends LowPriorityArbitrary2:
+
+  inline given equivalence[A, C1, C2](using C1 ==> C2, C2 ==> C1, Arbitrary[A :| C1]): Arbitrary[A :| C2] =
     summon[Arbitrary[A :| C1]].asInstanceOf
 
-  inline given [A, V <: A]: Arbitrary[A :| StrictEqual[V]] = Arbitrary(Gen.oneOf(Seq(constValue[V]))).asInstanceOf
+trait LowPriorityArbitrary2:
 
-trait LowPriorityArbitrary:
-
-  inline given[A: Arbitrary, C](using inline constraint: Constraint[A, C]): Arbitrary[A :| C] =
+  inline given fallback[A: Arbitrary, C](using inline constraint: Constraint[A, C]): Arbitrary[A :| C] =
     Arbitrary(arbitrary.filter(constraint.test(_))).asInstanceOf

--- a/scalacheck/src/io/github/iltotore/iron/scalacheck/any.scala
+++ b/scalacheck/src/io/github/iltotore/iron/scalacheck/any.scala
@@ -1,14 +1,18 @@
 package io.github.iltotore.iron.scalacheck
 
 import io.github.iltotore.iron.*
-
-import org.scalacheck.Arbitrary
+import io.github.iltotore.iron.constraint.any.StrictEqual
+import org.scalacheck.*
 import org.scalacheck.Arbitrary.arbitrary
+
+import scala.compiletime.constValue
 
 object any extends LowPriorityArbitrary:
 
   inline given [A, C1, C2](using C1 ==> C2, C2 ==> C1, Arbitrary[A :| C1]): Arbitrary[A :| C2] =
     summon[Arbitrary[A :| C1]].asInstanceOf
+
+  inline given [A, V <: A]: Arbitrary[A :| StrictEqual[V]] = Arbitrary(Gen.oneOf(Seq(constValue[V]))).asInstanceOf
 
 trait LowPriorityArbitrary:
 

--- a/scalacheck/src/io/github/iltotore/iron/scalacheck/char.scala
+++ b/scalacheck/src/io/github/iltotore/iron/scalacheck/char.scala
@@ -1,0 +1,24 @@
+package io.github.iltotore.iron.scalacheck
+
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.char.*
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Gen.Choose
+
+object char:
+
+  val whitespaceChars: Seq[Char] = (Char.MinValue to Char.MaxValue).filter(_.isWhitespace)
+
+  inline given whitespace: Arbitrary[Char :| Whitespace] = Arbitrary(Gen.oneOf(whitespaceChars)).asInstanceOf
+
+  inline given lowerCase: Arbitrary[Char :| LowerCase] = Arbitrary(Gen.alphaLowerChar).asInstanceOf
+
+  inline given upperCase: Arbitrary[Char :| UpperCase] = Arbitrary(Gen.alphaUpperChar).asInstanceOf
+
+  inline given digit: Arbitrary[Char :| Digit] = Arbitrary(Gen.numChar).asInstanceOf
+
+  inline given letter: Arbitrary[Char :| Letter] = Arbitrary(Gen.alphaChar).asInstanceOf
+
+  private val specialASCIIChars: Seq[Char] = (Char.MinValue until '0') ++ (':' until 'A') ++ ('[' until 'a') ++ ('{' to 127.toChar)
+
+  inline given special: Arbitrary[Char :| Special] = Arbitrary(Gen.oneOf(specialASCIIChars)).asInstanceOf

--- a/scalacheck/src/io/github/iltotore/iron/scalacheck/collection.scala
+++ b/scalacheck/src/io/github/iltotore/iron/scalacheck/collection.scala
@@ -1,0 +1,65 @@
+package io.github.iltotore.iron.scalacheck
+
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.collection.*
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Gen.Choose
+import org.scalacheck.util.Buildable
+
+import scala.collection.IterableFactory
+import scala.compiletime.constValue
+
+object collection:
+
+  inline given length[A, CC[_], C](using arbLength: Arbitrary[Int :| C], arbElem: Arbitrary[A], evb: Buildable[A,CC[A]], evt: CC[A] => Iterable[A]): Arbitrary[CC[A] :| Length[C]] =
+    Arbitrary(arbLength.arbitrary.flatMap(n => Gen.containerOfN(n, arbElem.arbitrary))).asInstanceOf
+
+  inline given contain[A, V <: A, CC[_]] (using arb: Arbitrary[A], buildable: Buildable[A, CC[A]], evt: CC[A] => Iterable[A]): Arbitrary[CC[A] :| Contain[V]] =
+    Arbitrary(
+      Gen.containerOf(arb.arbitrary)
+        .map(cc => (buildable.builder ++= evt(cc) += constValue[V]).result())
+    ).asInstanceOf
+
+  inline given forAll[A, CC[_], C](using arb: Arbitrary[A :| C], evb: Buildable[A :| C, CC[A :| C]], evt: CC[A :| C] => Iterable[A :| C]): Arbitrary[CC[A] :| ForAll[C]] =
+    Arbitrary.arbContainer[CC, A :| C].asInstanceOf
+
+  inline given init[A, CC[_], C](using arb: Arbitrary[A], arbConstrained: Arbitrary[A :| C], buildable: Buildable[A, CC[A]], evt: CC[A] => Iterable[A]): Arbitrary[CC[A] :| Init[C]] =
+    Arbitrary(
+      for
+        headValue <- arb.arbitrary
+        constrainedValues <- Gen.containerOf[CC, A](arbConstrained.arbitrary)
+      yield (buildable.builder ++= evt(constrainedValues) += headValue).result()
+    ).asInstanceOf
+
+  inline given tail[A, CC[_], C](using arb: Arbitrary[A], arbConstrained: Arbitrary[A :| C], buildable: Buildable[A, CC[A]], evt: CC[A] => Iterable[A]): Arbitrary[CC[A] :| Tail[C]] =
+    Arbitrary(
+      for
+        headValue <- arb.arbitrary
+        constrainedValues <- Gen.containerOf[CC, A](arbConstrained.arbitrary)
+      yield (buildable.builder += headValue ++= evt(constrainedValues) ).result()
+    ).asInstanceOf
+
+  inline given exists[A, CC[_], C](using arb: Arbitrary[A], arbConstrained: Arbitrary[A :| C], buildable: Buildable[A, CC[A]], evt: CC[A] => Iterable[A]): Arbitrary[CC[A] :| Exists[C]] =
+    Arbitrary(
+      for
+        constrainedValue <- arbConstrained.arbitrary
+        init <- Gen.containerOf[CC, A](arb.arbitrary)
+        tail <- Gen.containerOf[CC, A](arb.arbitrary)
+      yield (buildable.builder ++= evt(init) += constrainedValue ++= evt(tail)).result()
+    ).asInstanceOf
+
+  inline given head[A, CC[_], C](using arb: Arbitrary[A], arbConstrained: Arbitrary[A :| C], buildable: Buildable[A, CC[A]], evt: CC[A] => Iterable[A]): Arbitrary[CC[A] :| Head[C]] =
+    Arbitrary(
+      for
+        constrainedHead <- arbConstrained.arbitrary
+        tail <- Gen.containerOf[CC, A](arb.arbitrary)
+      yield (buildable.builder += constrainedHead ++= evt(tail)).result()
+    ).asInstanceOf
+
+  inline given last[A, CC[_], C](using arb: Arbitrary[A], arbConstrained: Arbitrary[A :| C], buildable: Buildable[A, CC[A]], evt: CC[A] => Iterable[A]): Arbitrary[CC[A] :| Last[C]] =
+    Arbitrary(
+      for
+        constrainedLast <- arbConstrained.arbitrary
+        init <- Gen.containerOf[CC, A](arb.arbitrary)
+      yield (buildable.builder ++= evt(init) += constrainedLast ).result()
+    ).asInstanceOf

--- a/scalacheck/src/io/github/iltotore/iron/scalacheck/macros.scala
+++ b/scalacheck/src/io/github/iltotore/iron/scalacheck/macros.scala
@@ -1,0 +1,25 @@
+package io.github.iltotore.iron.scalacheck
+
+import io.github.iltotore.iron.:|
+
+import org.scalacheck.*
+import scala.quoted.*
+
+private transparent inline def unionGen[A, C]: Gen[A :| C] = ${ unionGenImpl[A, C] }
+
+private def unionGenImpl[A, C](using Quotes, Type[A], Type[C]): Expr[Gen[A :| C]] =
+
+  import quotes.reflect.*
+
+  def rec(tpe: TypeRepr): Expr[Gen[?]] =
+    tpe.dealias match
+      case OrType(left, right) => '{ Gen.oneOf(${rec(left)}, ${rec(right)}) }
+      case constraintTpe =>
+
+        type ConstraintPart
+
+        given Type[ConstraintPart] = constraintTpe.asType.asInstanceOf
+
+        '{scala.compiletime.summonInline[Arbitrary[A :| ConstraintPart]].arbitrary}
+
+  '{${rec(TypeRepr.of[C])}.asInstanceOf[Gen[A :| C]]}.asExprOf[Gen[A :| C]]

--- a/scalacheck/src/io/github/iltotore/iron/scalacheck/numeric.scala
+++ b/scalacheck/src/io/github/iltotore/iron/scalacheck/numeric.scala
@@ -1,0 +1,37 @@
+package io.github.iltotore.iron.scalacheck
+
+import scala.compiletime.constValue
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.numeric.*
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen.Choose
+
+object numeric:
+
+  inline given gt[A : Numeric : Choose, V1 <: A](using max: Max[A], adj: Adjacent[A]): Arbitrary[A :| Greater[V1]] =
+    intervalArbitrary(adj.nextUp(constValue[V1]), max.value)
+
+  inline given gteq[A : Numeric: Choose, V1 <: A](using max: Max[A]): Arbitrary[A :| GreaterEqual[V1]] =
+    intervalArbitrary(constValue[V1], max.value)
+
+  inline given lt[A: Numeric: Choose, V1 <: A](using min: Min[A], adj: Adjacent[A]): Arbitrary[A :| Less[V1]] =
+    intervalArbitrary(min.value, adj.nextDown(constValue[V1]))
+
+  inline given lteq[A: Numeric: Choose, V1 <: A](using min: Min[A]): Arbitrary[A :| LessEqual[V1]] =
+    intervalArbitrary(min.value, constValue[V1])
+  
+  inline given closed[A : Numeric : Choose, V1 <: A, V2 <: A]: Arbitrary[A :| Interval.Closed[V1, V2]] =
+    intervalArbitrary(constValue[V1], constValue[V2])
+
+  inline given openClosed[A : Numeric : Choose, V1 <: A, V2 <: A](using adj: Adjacent[A]): Arbitrary[A :| Interval.OpenClosed[V1, V2]] =
+    intervalArbitrary(adj.nextUp(constValue[V1]), constValue[V2])
+
+  inline given closedOpen[A : Numeric : Choose, V1 <: A, V2 <: A](using adj: Adjacent[A]): Arbitrary[A :| Interval.ClosedOpen[V1, V2]] =
+    intervalArbitrary(constValue[V1], adj.nextDown(constValue[V2]))
+
+  inline given open[A : Numeric : Choose, V1 <: A, V2 <: A](using adj: Adjacent[A]): Arbitrary[A :| Interval.Open[V1, V2]] =
+    intervalArbitrary(adj.nextUp(constValue[V1]), adj.nextDown(constValue[V2]))
+
+  def intervalArbitrary[A : Numeric : Choose, C](min: A, max: A): Arbitrary[A :| C] =
+    Arbitrary(Gen.chooseNum(min, max)).asInstanceOf

--- a/scalacheck/src/io/github/iltotore/iron/scalacheck/string.scala
+++ b/scalacheck/src/io/github/iltotore/iron/scalacheck/string.scala
@@ -1,0 +1,16 @@
+package io.github.iltotore.iron.scalacheck
+
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.string.*
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Gen.Choose
+
+import scala.compiletime.constValue
+
+object string:
+
+  inline given startWith[V <: String]: Arbitrary[String :| StartWith[V]] =
+    Arbitrary(Gen.asciiStr.map(constValue[V] + _)).asInstanceOf
+
+  inline given endWith[V <: String]: Arbitrary[String :| EndWith[V]] =
+    Arbitrary(Gen.asciiStr.map(_ + constValue[V])).asInstanceOf

--- a/scalacheck/test/src/io/github/iltotore/iron/scalacheck/AnySuite.scala
+++ b/scalacheck/test/src/io/github/iltotore/iron/scalacheck/AnySuite.scala
@@ -1,0 +1,15 @@
+package io.github.iltotore.iron.scalacheck
+
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.any.*
+import io.github.iltotore.iron.scalacheck.any.given
+import org.scalacheck.*
+import utest.*
+
+object AnySuite extends TestSuite:
+
+  val tests: Tests = Tests {
+    test("fallback") - testGen[Boolean, StrictEqual[true]]
+
+    test("union") - testGen[Int, StrictEqual[1] | StrictEqual[2] | StrictEqual[3]]
+  }

--- a/scalacheck/test/src/io/github/iltotore/iron/scalacheck/CollectionSuite.scala
+++ b/scalacheck/test/src/io/github/iltotore/iron/scalacheck/CollectionSuite.scala
@@ -12,14 +12,40 @@ import utest.*
 object CollectionSuite extends TestSuite:
 
   val tests: Tests = Tests {
-    test("minLength") - testGen[Seq[Boolean], MinLength[5]]
-    test("maxLength") - testGen[Seq[Boolean], MaxLength[5]]
-    test("empty") - testGen[Seq[Boolean], Empty]
-    test("contain") - testGen[Seq[Boolean], Contain[5]]
-    test("forAll") - testGen[Seq[Boolean], ForAll[StrictEqual[true]]]
-    test("init") - testGen[Seq[Boolean], Init[StrictEqual[true]]]
-    test("tail") - testGen[Seq[Boolean], Tail[StrictEqual[true]]]
-    test("exists") - testGen[Seq[Boolean], Exists[StrictEqual[true]]]
-    test("head") - testGen[Seq[Boolean], Head[StrictEqual[true]]]
-    test("last") - testGen[Seq[Boolean], Last[StrictEqual[true]]]
+    test("minLength") {
+      test("seq") - testGen[Seq[Boolean], MinLength[5]]
+      test("string") - testGen[String, MinLength[5]]
+    }
+    test("maxLength") {
+      test("seq") - testGen[Seq[Boolean], MaxLength[5]]
+      test("string") - testGen[String, MaxLength[5]]
+    }
+    test("empty") {
+      test("seq") - testGen[Seq[Boolean], Empty]
+      test("string") - testGen[Seq[Boolean], Empty]
+    }
+    test("contain") {
+      test("seq") - testGen[Seq[Boolean], Contain[true]]
+      test("string") - testGen[String, Contain["a"]]
+    }
+    test("forAll") {
+      test("seq") - testGen[Seq[Boolean], ForAll[StrictEqual[true]]]
+      test("string") - testGen[String, ForAll[StrictEqual['a']]]
+    }
+    test("init") {
+      test("seq") - testGen[Seq[Boolean], Init[StrictEqual[true]]]
+      test("string") - testGen[String, Init[StrictEqual['a']]]
+    }
+    test("tail") {
+      test("seq") - testGen[Seq[Boolean], Tail[StrictEqual[true]]]
+      test("string") - testGen[String, Tail[StrictEqual['a']]]
+    }
+    test("head") {
+      test("seq") - testGen[Seq[Boolean], Head[StrictEqual[true]]]
+      test("string") - testGen[String, Head[StrictEqual['a']]]
+    }
+    test("last") {
+      test("seq") - testGen[Seq[Boolean], Last[StrictEqual[true]]]
+      test("string") - testGen[String, Last[StrictEqual['a']]]
+    }
   }

--- a/scalacheck/test/src/io/github/iltotore/iron/scalacheck/CollectionSuite.scala
+++ b/scalacheck/test/src/io/github/iltotore/iron/scalacheck/CollectionSuite.scala
@@ -1,0 +1,25 @@
+package io.github.iltotore.iron.scalacheck
+
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.all.*
+import io.github.iltotore.iron.constraint.numeric.*
+import io.github.iltotore.iron.scalacheck.any.given
+import io.github.iltotore.iron.scalacheck.collection.given
+import io.github.iltotore.iron.scalacheck.numeric.given
+import org.scalacheck.*
+import utest.*
+
+object CollectionSuite extends TestSuite:
+
+  val tests: Tests = Tests {
+    test("minLength") - testGen[Seq[Boolean], MinLength[5]]
+    test("maxLength") - testGen[Seq[Boolean], MaxLength[5]]
+    test("empty") - testGen[Seq[Boolean], Empty]
+    test("contain") - testGen[Seq[Boolean], Contain[5]]
+    test("forAll") - testGen[Seq[Boolean], ForAll[StrictEqual[true]]]
+    test("init") - testGen[Seq[Boolean], Init[StrictEqual[true]]]
+    test("tail") - testGen[Seq[Boolean], Tail[StrictEqual[true]]]
+    test("exists") - testGen[Seq[Boolean], Exists[StrictEqual[true]]]
+    test("head") - testGen[Seq[Boolean], Head[StrictEqual[true]]]
+    test("last") - testGen[Seq[Boolean], Last[StrictEqual[true]]]
+  }

--- a/scalacheck/test/src/io/github/iltotore/iron/scalacheck/NumericSuite.scala
+++ b/scalacheck/test/src/io/github/iltotore/iron/scalacheck/NumericSuite.scala
@@ -1,0 +1,70 @@
+package io.github.iltotore.iron.scalacheck
+
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.numeric.*
+import io.github.iltotore.iron.scalacheck.numeric.given
+import org.scalacheck.*
+import utest.*
+
+object NumericSuite extends TestSuite:
+
+  val tests: Tests = Tests {
+
+    test("greater") {
+      test("int") - testGen[Int, Greater[5]]
+      test("long") - testGen[Long, Greater[5L]]
+      test("float") - testGen[Float, Greater[5f]]
+      test("double") - testGen[Double, Greater[5d]]
+    }
+
+    test("greaterEqual") {
+      test("int") - testGen[Int, GreaterEqual[5]]
+      test("long") - testGen[Long, GreaterEqual[5L]]
+      test("float") - testGen[Float, GreaterEqual[5f]]
+      test("double") - testGen[Double, GreaterEqual[5d]]
+    }
+
+    test("less") {
+      test("int") - testGen[Int, Less[5]]
+      test("long") - testGen[Long, Less[5L]]
+      test("float") - testGen[Float, Less[5f]]
+      test("double") - testGen[Double, Less[5d]]
+    }
+
+    test("lessEqual") {
+      test("int") - testGen[Int, LessEqual[5]]
+      test("long") - testGen[Long, LessEqual[5L]]
+      test("float") - testGen[Float, LessEqual[5f]]
+      test("double") - testGen[Double, LessEqual[5d]]
+    }
+
+    test("interval") {
+      test("open") {
+        test("int") - testGen[Int, Interval.Open[0, 5]]
+        test("long") - testGen[Long, Interval.Open[0L, 5L]]
+        test("float") - testGen[Float, Interval.Open[0f, 5f]]
+        test("double") - testGen[Double, Interval.Open[0d, 5d]]
+      }
+
+      test("openClosed") {
+        test("int") - testGen[Int, Interval.OpenClosed[0, 5]]
+        test("long") - testGen[Long, Interval.OpenClosed[0L, 5L]]
+        test("float") - testGen[Float, Interval.OpenClosed[0f, 5f]]
+        test("double") - testGen[Double, Interval.OpenClosed[0d, 5d]]
+      }
+
+      test("closedOpen") {
+        test("int") - testGen[Int, Interval.ClosedOpen[0, 5]]
+        test("long") - testGen[Long, Interval.ClosedOpen[0L, 5L]]
+        test("float") - testGen[Float, Interval.ClosedOpen[0f, 5f]]
+        test("double") - testGen[Double, Interval.ClosedOpen[0d, 5d]]
+      }
+
+      test("closed") {
+        test("int") - testGen[Int, Interval.Closed[0, 5]]
+        test("long") - testGen[Long, Interval.Closed[0L, 5L]]
+        test("float") - testGen[Float, Interval.Closed[0f, 5f]]
+        test("double") - testGen[Double, Interval.Closed[0d, 5d]]
+      }
+    }
+  }

--- a/scalacheck/test/src/io/github/iltotore/iron/scalacheck/StringSuite.scala
+++ b/scalacheck/test/src/io/github/iltotore/iron/scalacheck/StringSuite.scala
@@ -1,0 +1,14 @@
+package io.github.iltotore.iron.scalacheck
+
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.string.*
+import io.github.iltotore.iron.scalacheck.string.given
+import org.scalacheck.*
+import utest.*
+
+object StringSuite extends TestSuite:
+
+  val tests: Tests = Tests {
+    test("startWith") - testGen[String, StartWith["abc"]]
+    test("endWith") - testGen[String, EndWith["abc"]]
+  }

--- a/scalacheck/test/src/io/github/iltotore/iron/scalacheck/package.scala
+++ b/scalacheck/test/src/io/github/iltotore/iron/scalacheck/package.scala
@@ -1,7 +1,18 @@
 package io.github.iltotore.iron.scalacheck
 
 import io.github.iltotore.iron.{:|, Constraint}
-import org.scalacheck.{Arbitrary, Prop}
+import org.scalacheck.{Arbitrary, Prop, Test}
+import utest.*
 
 inline def testGen[A, C](using inline arb: Arbitrary[A :| C], inline constraint: Constraint[A, C]): Unit =
-  Prop.forAll(arb.arbitrary)(constraint.test(_)).check()
+
+  def getTestValues(args: List[Prop.Arg[Any]]): List[TestValue] =
+    args.zipWithIndex.map((arg, i) => TestValue(if arg.label.isBlank then s"value$i" else arg.label, "T", arg.arg))
+
+  Test.check(Prop.forAll(arb.arbitrary)(constraint.test(_)))(p => p).status match
+    case Test.Passed | Test.Proved(_) =>
+    case Test.Failed(args, _) =>
+      throw AssertionError(s"Some constrained values failed for ${constraint.message}", getTestValues(args))
+    case Test.Exhausted => new java.lang.AssertionError("Exhausted")
+    case Test.PropException(args, e, _) =>
+      throw AssertionError(s"An error occurred for ${constraint.message}", getTestValues(args), e)

--- a/scalacheck/test/src/io/github/iltotore/iron/scalacheck/package.scala
+++ b/scalacheck/test/src/io/github/iltotore/iron/scalacheck/package.scala
@@ -1,0 +1,7 @@
+package io.github.iltotore.iron.scalacheck
+
+import io.github.iltotore.iron.{:|, Constraint}
+import org.scalacheck.{Arbitrary, Prop}
+
+inline def testGen[A, C](using inline arb: Arbitrary[A :| C], inline constraint: Constraint[A, C]): Unit =
+  Prop.forAll(arb.arbitrary)(constraint.test(_)).check()


### PR DESCRIPTION
Add `org.scalacheck.Arbitrary` instances for refined types.

Closes #66 