### PR TITLE
feat: Beautify compile-time errors

### DIFF
--- a/main/src/io/github/iltotore/iron/internal/Validation.scala
+++ b/main/src/io/github/iltotore/iron/internal/Validation.scala
@@ -1,4 +1,4 @@
-package io.github.iltotore.iron.util
+package io.github.iltotore.iron.internal
 
 enum Validation[L, R]:
   case Valid(value: R)

--- a/main/src/io/github/iltotore/iron/macros/intersection.scala
+++ b/main/src/io/github/iltotore/iron/macros/intersection.scala
@@ -1,7 +1,7 @@
 package io.github.iltotore.iron.macros
 
-import io.github.iltotore.iron.util.*
-import io.github.iltotore.iron.util.Validation.{Valid, Invalid}
+import io.github.iltotore.iron.internal.*
+import io.github.iltotore.iron.internal.Validation.{Valid, Invalid}
 import scala.quoted.*
 
 /**

--- a/main/src/io/github/iltotore/iron/macros/intersection.scala
+++ b/main/src/io/github/iltotore/iron/macros/intersection.scala
@@ -1,5 +1,7 @@
 package io.github.iltotore.iron.macros
 
+import io.github.iltotore.iron.util.*
+import io.github.iltotore.iron.util.Validation.{Valid, Invalid}
 import scala.quoted.*
 
 /**
@@ -38,20 +40,28 @@ object intersection:
 
     val constraintTpe = TypeRepr.of[io.github.iltotore.iron.Constraint]
 
-    def rec(tpe: TypeRepr): Expr[Boolean] =
+    def rec(tpe: TypeRepr): Validation[TypeRepr, Expr[Boolean]] =
       tpe.dealias match
-        case AndType(left, right) => '{ ${ rec(left) } && ${ rec(right) } }
+        case AndType(left, right) =>
+          rec(left)
+            .accumulate(rec(right))
+            .map((leftResult, rightResult) => '{ $leftResult && $rightResult })
         case t =>
           val implTpe = constraintTpe.appliedTo(List(aTpe, t))
 
           Implicits.search(implTpe) match
             case iss: ImplicitSearchSuccess =>
               val implTerm = iss.tree
-              Apply(Select.unique(implTerm, "test"), List(value.asTerm)).asExprOf[Boolean]
+              Valid(Apply(Select.unique(implTerm, "test"), List(value.asTerm)).asExprOf[Boolean])
 
-            case isf: ImplicitSearchFailure => report.errorAndAbort(s"Could not find implicit ${implTpe}")
+            case isf: ImplicitSearchFailure => Invalid(List(t))
 
-    rec(TypeRepr.of[C])
+    rec(TypeRepr.of[C]) match
+      case Valid(value) => value
+      case Invalid(errors) =>
+        val missingTypes = errors.map(tpe => s"- ${tpe.show}").mkString("\n")
+        compileTimeError(s"""|Missing given instances of Constraint[${aTpe.show}, ...] in intersection for types:
+                             |$missingTypes""".stripMargin)
 
   /**
    * Constraint message for intersection type.
@@ -69,17 +79,25 @@ object intersection:
 
     val constraintTpe = TypeRepr.of[io.github.iltotore.iron.Constraint]
 
-    def rec(tpe: TypeRepr): Expr[String] =
+    def rec(tpe: TypeRepr)(using Quotes): Validation[TypeRepr, Expr[String]] =
       tpe.dealias match
-        case AndType(left, right) => '{ ${ rec(left) } + " & " + ${ rec(right) } }
+        case AndType(left, right) =>
+          rec(left)
+            .accumulate(rec(right))
+            .map((leftResult, rightResult) => '{ $leftResult + " & " + $rightResult })
         case t =>
           val implTpe = constraintTpe.appliedTo(List(aTpe, t))
 
           Implicits.search(implTpe) match
             case iss: ImplicitSearchSuccess =>
               val implTerm = iss.tree
-              Select.unique(implTerm, "message").asExprOf[String]
+              Valid(Select.unique(implTerm, "message").asExprOf[String])
 
-            case isf: ImplicitSearchFailure => report.errorAndAbort(s"Could not find implicit $implTpe")
+            case isf: ImplicitSearchFailure => Invalid(List(t))
 
-    '{ "(" + ${ rec(TypeRepr.of[C]) } + ")" }
+    rec(TypeRepr.of[C]) match
+      case Valid(value) => value
+      case Invalid(errors) =>
+        val missingTypes = errors.map(tpe => s"- ${tpe.show}").mkString("\n")
+        compileTimeError(s"""|Missing given instances of Constraint[${aTpe.show}, ...] in intersection for types:
+                             |$missingTypes""".stripMargin)

--- a/main/src/io/github/iltotore/iron/macros/package.scala
+++ b/main/src/io/github/iltotore/iron/macros/package.scala
@@ -111,7 +111,7 @@ private def assertConditionImpl[A: Type](input: Expr[A], cond: Expr[Boolean], me
   val messageValue = message.value.getOrElse("<Unknown message>")
   val condValue = cond.value
     .getOrElse(
-      report.errorAndAbort(
+      compileTimeError(
         s"""Cannot refine value at compile-time because the predicate cannot be evaluated.
            |This is likely because the condition or the input value isn't fully inlined.
            |
@@ -138,7 +138,7 @@ private def nonConstantErrorImpl[A](expr: Expr[A])(using Quotes): Nothing =
 
   import quotes.reflect.*
 
-  report.errorAndAbort(
+  compileTimeError(
     s"""Cannot refine non full inlined input at compile-time.
        |To test a constraint at runtime, use the `refined` extension method.
        |
@@ -175,3 +175,10 @@ private def isConstantImpl[A: Type](expr: Expr[A])(using Quotes): Expr[Boolean] 
     else false
 
   Expr(result)
+
+def compileTimeError(msg: String)(using Quotes): Nothing =
+  quotes.reflect.report.errorAndAbort(
+  s"""|—— Compile-time Error —————————————————————————————————————————————————————
+      |$msg
+      |———————————————————————————————————————————————————————————————————————————""".stripMargin
+  )

--- a/main/src/io/github/iltotore/iron/macros/package.scala
+++ b/main/src/io/github/iltotore/iron/macros/package.scala
@@ -184,7 +184,7 @@ private def isConstantImpl[A: Type](expr: Expr[A])(using Quotes): Expr[Boolean] 
 
 def compileTimeError(msg: String)(using Quotes): Nothing =
   quotes.reflect.report.errorAndAbort(
-  s"""|—— Compile-time Error —————————————————————————————————————————————————————
+  s"""|-- Compile-time Error ------------------------------------------------------
       |$msg
-      |———————————————————————————————————————————————————————————————————————————""".stripMargin
+      |----------------------------------------------------------------------------""".stripMargin
   )

--- a/main/src/io/github/iltotore/iron/macros/package.scala
+++ b/main/src/io/github/iltotore/iron/macros/package.scala
@@ -126,7 +126,7 @@ private def assertConditionImpl[A : Type](input: Expr[A], cond: Expr[Boolean], m
     )
 
   if !condValue then
-    compileTimeError(s"""|A constraint did not pass for type $CYAN${inputType.show}$RESET.
+    compileTimeError(s"""|Could not satisfy a constraint for type $CYAN${inputType.show}$RESET.
                          |
                          |${CYAN}Value$RESET: ${input.show}
                          |${CYAN}Message$RESET: $messageValue""".stripMargin)
@@ -184,7 +184,7 @@ private def isConstantImpl[A: Type](expr: Expr[A])(using Quotes): Expr[Boolean] 
 
 def compileTimeError(msg: String)(using Quotes): Nothing =
   quotes.reflect.report.errorAndAbort(
-  s"""|-- Compile-time Error ------------------------------------------------------
+  s"""|-- Constraint Error --------------------------------------------------------
       |$msg
       |----------------------------------------------------------------------------""".stripMargin
   )

--- a/main/src/io/github/iltotore/iron/macros/package.scala
+++ b/main/src/io/github/iltotore/iron/macros/package.scala
@@ -140,7 +140,7 @@ private def nonConstantErrorImpl[A](expr: Expr[A])(using Quotes): Nothing =
 
   compileTimeError(
     s"""Cannot refine non full inlined input at compile-time.
-       |To test a constraint at runtime, use the `refined` extension method.
+       |To test a constraint at runtime, use the `refine` extension method.
        |
        |Note: Due to a Scala limitation, already-refined types cannot be tested at compile-time (unless proven by an `Implication`).
        |

--- a/main/src/io/github/iltotore/iron/macros/union.scala
+++ b/main/src/io/github/iltotore/iron/macros/union.scala
@@ -1,6 +1,8 @@
 package io.github.iltotore.iron.macros
 
 import io.github.iltotore.iron.{Constraint, Implication, ==>}
+import io.github.iltotore.iron.util.*
+import io.github.iltotore.iron.util.Validation.{Valid, Invalid}
 import scala.quoted.*
 
 /**
@@ -38,20 +40,29 @@ object union:
 
     val constraintTpe = TypeRepr.of[Constraint]
 
-    def rec(tpe: TypeRepr): Expr[Boolean] =
+    def rec(tpe: TypeRepr): Validation[TypeRepr, Expr[Boolean]] =
       tpe.dealias match
-        case OrType(left, right) => '{ ${ rec(left) } || ${ rec(right) } }
+        case OrType(left, right) =>
+          rec(left)
+          .accumulate(rec(right))
+          .map((leftResult, rightResult) => '{ $leftResult || $rightResult })
+            
         case t =>
           val implTpe = constraintTpe.appliedTo(List(aTpe, t))
 
           Implicits.search(implTpe) match
             case iss: ImplicitSearchSuccess =>
               val implTerm = iss.tree
-              Apply(Select.unique(implTerm, "test"), List(value.asTerm)).asExprOf[Boolean]
+              Valid(Apply(Select.unique(implTerm, "test"), List(value.asTerm)).asExprOf[Boolean])
 
-            case isf: ImplicitSearchFailure => report.errorAndAbort(s"Could not find implicit ${implTpe}")
+            case isf: ImplicitSearchFailure => Invalid(List(t))
 
-    rec(TypeRepr.of[C])
+    rec(TypeRepr.of[C]) match
+      case Valid(value) => value
+      case Invalid(errors) =>
+        val missingTypes = errors.map(tpe => s"- ${tpe.show}").mkString("\n")
+        compileTimeError(s"""|Missing given instances of Constraint[${aTpe.show}, ...] in union for types:
+                             |$missingTypes""".stripMargin)
 
   /**
    * Constraint message for union type.
@@ -69,20 +80,28 @@ object union:
 
     val constraintTpe = TypeRepr.of[Constraint]
 
-    def rec(tpe: TypeRepr): Expr[String] =
+    def rec(tpe: TypeRepr)(using Quotes): Validation[TypeRepr, Expr[String]] =
       tpe.dealias match
-        case OrType(left, right) => '{ ${ rec(left) } + " | " + ${ rec(right) } }
+        case OrType(left, right) =>
+          rec(left)
+            .accumulate(rec(right))
+            .map((leftResult, rightResult) => '{ $leftResult + " | " + $rightResult })
         case t =>
           val implTpe = constraintTpe.appliedTo(List(aTpe, t))
 
           Implicits.search(implTpe) match
             case iss: ImplicitSearchSuccess =>
               val implTerm = iss.tree
-              Select.unique(implTerm, "message").asExprOf[String]
+              Valid(Select.unique(implTerm, "message").asExprOf[String])
 
-            case isf: ImplicitSearchFailure => report.errorAndAbort(s"Could not find implicit $implTpe")
+            case isf: ImplicitSearchFailure => Invalid(List(t))
 
-    '{ "(" + ${ rec(TypeRepr.of[C]) } + ")" }
+    rec(TypeRepr.of[C]) match
+      case Valid(value) => '{ "(" + $value + ")" }
+      case Invalid(errors) =>
+        val missingTypes = errors.map(tpe => s"- ${tpe.show}").mkString("\n")
+        compileTimeError(s"""|Missing given instances of Constraint[${aTpe.show}, ...] in union for types:
+                             |$missingTypes""".stripMargin)
 
   /**
    * [[Implication]] for union type.

--- a/main/src/io/github/iltotore/iron/macros/union.scala
+++ b/main/src/io/github/iltotore/iron/macros/union.scala
@@ -1,8 +1,8 @@
 package io.github.iltotore.iron.macros
 
 import io.github.iltotore.iron.{Constraint, Implication, ==>}
-import io.github.iltotore.iron.util.*
-import io.github.iltotore.iron.util.Validation.{Valid, Invalid}
+import io.github.iltotore.iron.internal.*
+import io.github.iltotore.iron.internal.Validation.{Valid, Invalid}
 import scala.quoted.*
 
 /**

--- a/main/src/io/github/iltotore/iron/util/Validation.scala
+++ b/main/src/io/github/iltotore/iron/util/Validation.scala
@@ -1,0 +1,20 @@
+package io.github.iltotore.iron.util
+
+enum Validation[L, R]:
+  case Valid(value: R)
+  case Invalid(list: List[L])
+
+import Validation.*
+
+extension [L, R](validation: Validation[L, R])
+
+  def accumulate[L2, R2](other: Validation[L2, R2]): Validation[L | L2, (R, R2)] = (validation, other) match
+    case (Valid(value), Valid(otherValue)) => Valid((value, otherValue))
+    case (Valid(_), Invalid(otherErrors)) => Invalid(otherErrors)
+    case (Invalid(errors), Valid(_)) => Invalid(errors)
+    case (Invalid(errors), Invalid(otherErrors)) => Invalid((errors ++ otherErrors).asInstanceOf)
+
+  def map[R2](f: R => R2): Validation[L, R2] = validation match
+    case Valid(value) => Valid(f(value))
+    case Invalid(errors) => Invalid(errors)
+  


### PR DESCRIPTION
New messages are inspired from [kitlangton/neotype](https://github.com/kitlangton/neotype).

Union/Intersection:

```scala
final class Foo
final class Bar

val x: Int :| (Even | Foo | Bar) = 5
```

```
-- Compile-time Error ------------------------------------------------------
Missing given instances of Constraint[scala.Int, ...] in union for types:
- Main.Foo
- Main.Bar
----------------------------------------------------------------------------
```

Constraint not passing at compile-time:

```scala
val x: Int :| Positive = -1
```

```
-- Compile-time Error ------------------------------------------------------
A constraint did not pass for type scala.Int.

Value: -1
Message: Should be strictly positive
----------------------------------------------------------------------------
```

Closes #111 

@vbergeron-ledger I would like to have users' opinion about these new error messages.