### PR TITLE
feat: Add refineFurther methods to chain refinements

### DIFF
--- a/cats/src/io/github/iltotore/iron/cats.scala
+++ b/cats/src/io/github/iltotore/iron/cats.scala
@@ -64,6 +64,60 @@ object cats extends IronCatsInstances:
     inline def refineValidatedNel[C](using inline constraint: Constraint[A, C]): ValidatedNel[String, A :| C] =
       Validated.condNel(constraint.test(value), value.asInstanceOf[A :| C], constraint.message)
 
+  extension [A, C1](value: A :| C1)
+
+    /**
+     * Refine the given value again at runtime, resulting in an [[EitherNec]].
+     *
+     * @param constraint the new constraint to test.
+     * @return a [[Right]] containing this refined with `C1 & C2` or a [[Left]] containing the constraint message.
+     * @see [[refineNec]].
+     */
+    inline def refineFurtherNec[C2](using inline constraint: Constraint[A, C2]): EitherNec[String, A :| (C1 & C2)] =
+      value.refineFurtherEither[C2].toEitherNec
+
+    /**
+     * Refine the given value again at runtime, resulting in an [[EitherNel]].
+     *
+     * @param constraint the new constraint to test.
+     * @return a [[Right]] containing this refined with `C1 & C2` or a [[Left]] containing the constraint message.
+     * @see [[refineNel]].
+     */
+    inline def refineFurtherNel[C2](using inline constraint: Constraint[A, C2]): EitherNel[String, A :| (C1 & C2)] =
+      value.refineFurtherEither[C2].toEitherNel
+
+    /**
+     * Refine the given value again at runtime, resulting in an [[Validated]].
+     *
+     * @param constraint the new constraint to test.
+     * @return a [[Validated.Valid]] containing this refined with `C1 & C2` or a [[Validated.Invalid]] containing the constraint message.
+     * @see [[refineValidated]].
+     */
+    inline def refineFurtherValidated[C2](using inline constraint: Constraint[A, C2]): Validated[String, A :| (C1 & C2)] =
+      (value: A).refineValidated[C2].map(_.assumeFurther[C1])
+
+    /**
+     * Refine the given value again applicatively at runtime, resulting in a [[ValidatedNec]].
+     *
+     * @param constraint the new constraint to test.
+     * @return a [[Valid]] containing this value as [[IronType]] or an [[Invalid]] containing a [[NonEmptyChain]] of error messages.
+     * @see [[refineValidatedNec]].
+     */
+    inline def refineFurtherValidatedNec[C2](using inline constraint: Constraint[A, C2]): ValidatedNec[String, A :| (C1 & C2)] =
+      (value: A).refineValidatedNec[C2].map(_.assumeFurther[C1])
+
+    /**
+     * Refine the given value again applicatively at runtime, resulting in a [[ValidatedNel]].
+     *
+     * @param constraint the new constraint to test.
+     * @return a [[Valid]] containing this value as [[IronType]] or an [[Invalid]] containing a [[NonEmptyList]] of error messages.
+     * @see [[refineValidatedNec]].
+     */
+    inline def refineFurtherValidatedNel[C2](using inline constraint: Constraint[A, C2]): ValidatedNel[String, A :| (C1 & C2)] =
+      (value: A).refineValidatedNel[C2].map(_.assumeFurther[C1])
+
+
+
 /**
  * Represent all Cats' typeclass instances for Iron.
  */

--- a/docs/_docs/reference/refinement.md
+++ b/docs/_docs/reference/refinement.md
@@ -51,6 +51,8 @@ val x: Int :| Greater[0] = value //OK
 
 ## Runtime refinement
 
+### Imperative
+
 Sometimes, you want to refine a value that is not available at compile time. For example in the case of form validation.
 
 ```scala
@@ -73,6 +75,8 @@ The `refine` extension method tests the constraint at runtime, throwing an `Ille
 didn't pass
 the assertion.
 
+### Functional
+
 Iron also provides methods similar to `refine` but returning an `Option` (`refineOption`) or
 an `Either` (`refineEither`), useful for data validation:
 
@@ -92,3 +96,124 @@ createUser("Il_totore", 18) //Left("Should be alphanumeric")
 createUser("Iltotore", 0) //Left("Should be greater than 0")
 createUser("Iltotore", 18) //Right(User("Iltotore", 18))
 ```
+
+### Accumulative error
+
+You can accumulate refinement errors using the [Cats](../modules/cats.md) or [ZIO](../modules/zio.md) module.
+Here is an example with the latter:
+
+```scala
+import zio.prelude.Validation
+
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.all.*
+import io.github.iltotore.iron.zio.*
+
+
+type Username = Alphanumeric DescribedAs "Username should be alphanumeric"
+
+type Age = Positive DescribedAs "Age should be positive"
+
+case class User(name: String :| Username, age: Int :| Age)
+
+def createUser(name: String, age: Int): Validation[String, User] =
+  Validation.validateWith(
+    name.refineValidation[Username],
+    age.refineValidation[Age]
+  )(User.apply)
+
+createUser("Iltotore", 18) //Success(Chunk(),User(Iltotore,18))
+createUser("Il_totore", 18) //Failure(Chunk(),NonEmptyChunk(Username should be alphanumeric))
+createUser("Il_totore", -18) //Failure(Chunk(),NonEmptyChunk(Username should be alphanumeric, Age should be positive))
+```
+
+This is useful for forms where you want to report all input errors to the user and not short-circuit like an `Either`.
+
+Check the [Cats module](../modules/cats.md) or [ZIO module](../modules/zio.md) page for further information.
+
+### Refining further
+
+Sometimes you want to refine the same value multiple times with different constraints.
+This is especially useful when you want fine-grained refinement errors. Let's take the last example but with passwords:
+
+```scala
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.all.*
+
+type Username = DescribedAs[Alphanumeric, "Username should be alphanumeric"]
+type Password = DescribedAs[
+  Alphanumeric & MinLength[5] & Exists[Letter] & Exists[Digit],
+  "Password should have at least 5 characters, be alphanumeric and contain at least one letter and one digit"
+]
+
+case class User(name: String :| Username, password: String :| Password)
+
+def createUser(name: String, password: String): Either[String, User] =
+  for
+    validName     <- name.refineEither[Username]
+    validPassword <- password.refineEither[Password]
+  yield
+    User(validName, validPassword)
+
+createUser("Iltotore", "abc123") //Right(User("Iltotore", "abc123"))
+createUser("Iltotore", "abc") //Left("Password should have at least 5 characters, be alphanumeric and contain at least one letter and one digit")
+```
+
+At the last line, we get a `Left` saying that our password is invalid.
+However, it's not clear which constraint is not satisfied: is my password to short? Should I add a digit? etc...
+
+Using `refineFurther`/`refineFurtherEither`/... enables more detailed messages:
+
+```scala
+type Username = DescribedAs[Alphanumeric, "Username should be alphanumeric"]
+type Password = DescribedAs[
+  Alphanumeric & MinLength[5] & Exists[Letter] & Exists[Digit],
+  "Password should have at least 5 characters, be alphanumeric and contain at least one letter and one digit"
+]
+
+case class User(name: String :| Username, password: String :| Password)
+
+def createUser(name: String, password: String): Either[String, User] =
+  for
+    validName     <- name.refineEither[Username]
+    alphanumeric  <- password.refineEither[Alphanumeric]
+    minLength     <- alphanumeric.refineFurtherEither[MinLength[5]]
+    hasLetter     <- minLength.refineFurtherEither[Exists[Letter]]
+    validPassword <- hasLetter.refineFurtherEither[Exists[Digit]]
+  yield
+    User(validName, validPassword)
+
+createUser("Iltotore", "abc123") //Right(User("Iltotore", "abc123"))
+createUser("Iltotore", "abc1") //Left("Should have a minimum length of 5")
+createUser("Iltotore", "abcde") //Left("At least one element: (Should be a digit)")
+createUser("Iltotore", "abc123  ") //Left("Should be alphanumeric")
+```
+
+Or with custom error messages:
+
+```scala
+type Username = DescribedAs[Alphanumeric, "Username should be alphanumeric"]
+type Password = DescribedAs[
+  Alphanumeric & MinLength[5] & Exists[Letter] & Exists[Digit],
+  "Password should have at least 5 characters, be alphanumeric and contain at least one letter and one digit"
+]
+
+case class User(name: String :| Username, password: String :| Password)
+
+def createUser(name: String, password: String): Either[String, User] =
+  for
+    validName     <- name.refineEither[Username]
+    alphanumeric  <- password.refineEither[Alphanumeric].left.map(_ => "Your password should be alphanumeric")
+    minLength     <- alphanumeric.refineFurtherEither[MinLength[5]].left.map(_ => "Your password should have a minimum length of 5")
+    hasLetter     <- minLength.refineFurtherEither[Exists[Letter]].left.map(_ => "Your password should contain at least a letter")
+    validPassword <- hasLetter.refineFurtherEither[Exists[Digit]].left.map(_ => "Your password should contain at least a digit")
+  yield
+    User(validName, validPassword)
+
+createUser("Iltotore", "abc123") //Right(User("Iltotore", "abc123"))
+createUser("Iltotore", "abc1") //Left("Your password should have a minimum length of 5")
+createUser("Iltotore", "abcde") //Left("Your password should contain at least a digit")
+createUser("Iltotore", "abc123  ") //Left("Your password should be alphanumeric")
+```
+
+Note: Accumulative versions exist for [Cats](../modules/cats.md) and [ZIO](../modules/zio.md).

--- a/docs/_docs/reference/refinement.md
+++ b/docs/_docs/reference/refinement.md
@@ -51,8 +51,6 @@ val x: Int :| Greater[0] = value //OK
 
 ## Runtime refinement
 
-### Imperative
-
 Sometimes, you want to refine a value that is not available at compile time. For example in the case of form validation.
 
 ```scala
@@ -64,7 +62,11 @@ val username: String :| Alphanumeric = runtimeString
 ```
 
 This snippet would not compile because `runtimeString` is not evaluable at compile time.
-Fortunately, Iron supports explicit runtime checking through `refine`:
+Fortunately, Iron supports explicit runtime checking using extension methods
+
+### Imperative
+
+You can imperatively refine a value at runtime (much like an assertion) using the `refine[C]` method:
 
 ```scala
 val runtimeString: String = ???
@@ -72,8 +74,7 @@ val username: String :| Alphanumeric = runtimeString.refine //or more explicitly
 ```
 
 The `refine` extension method tests the constraint at runtime, throwing an `IllegalArgumentException` if the value
-didn't pass
-the assertion.
+does not pass the assertion.
 
 ### Functional
 
@@ -217,3 +218,30 @@ createUser("Iltotore", "abc123  ") //Left("Your password should be alphanumeric"
 ```
 
 Note: Accumulative versions exist for [Cats](../modules/cats.md) and [ZIO](../modules/zio.md).
+
+## Assuming constraints
+
+Sometimes, you know that your value always passes (possibly at runtime) a constraint. For example:
+
+```scala
+val random = scala.util.Random.nextInt(9)+1
+val x: Int :| Positive = random
+```
+
+This code will not compile (see [Runtime refinement](#runtime-refinement)).
+We could use `refine` but we don't actually need to apply the constraint to `random`.
+Instead, we can can use `assume[C]`. It simply acts like a safer cast.
+
+```scala
+val random = scala.util.Random.nextInt(9)+1
+val x: Int :| Positive = random.assume
+```
+
+This code will compile to:
+
+```scala
+val random: Int = scala.util.Random.nextInt(9)+1
+val x: Int = random
+```
+
+leaving no overhead.

--- a/main/src/io/github/iltotore/iron/compileTime.scala
+++ b/main/src/io/github/iltotore/iron/compileTime.scala
@@ -152,9 +152,9 @@ object compileTime:
    * @tparam A the constant type to cast.
    */
   type ToDouble[A <: NumConstant] <: Double = A match
-    case Int => int.ToDouble[A]
-    case Long => long.ToDouble[A]
-    case Float => float.ToDouble[A]
+    case Int    => int.ToDouble[A]
+    case Long   => long.ToDouble[A]
+    case Float  => float.ToDouble[A]
     case Double => A & Double
 
   /**
@@ -173,7 +173,9 @@ object compileTime:
    */
   transparent inline def stringValue[A]: String = constValue[ToString[A]]
 
-  def applyConstraint[A, C, Impl <: Constraint[A, C]](expr: Expr[A], constraintExpr: Expr[Impl])(using Quotes): Expr[Boolean] = // Using quotes directly causes a "deferred inline error"
+  def applyConstraint[A, C, Impl <: Constraint[A, C]](expr: Expr[A], constraintExpr: Expr[Impl])(using
+      Quotes
+  ): Expr[Boolean] = // Using quotes directly causes a "deferred inline error"
 
     import quotes.reflect.*
 

--- a/main/src/io/github/iltotore/iron/constraint/any.scala
+++ b/main/src/io/github/iltotore/iron/constraint/any.scala
@@ -143,7 +143,10 @@ object any:
 
       override inline def message: String = "(" + summonInline[Impl1].message + " xor " + summonInline[Impl2].message + ")"
 
-    inline given [A, C1, C2, Impl1 <: Constraint[A, C1], Impl2 <: Constraint[A, C2]](using inline impl1: Impl1, impl2: Impl2): XorConstraint[A, C1, C2, Impl1, Impl2] =
+    inline given [A, C1, C2, Impl1 <: Constraint[A, C1], Impl2 <: Constraint[A, C2]](using
+        inline impl1: Impl1,
+        impl2: Impl2
+    ): XorConstraint[A, C1, C2, Impl1, Impl2] =
       new XorConstraint
 
     /**

--- a/main/src/io/github/iltotore/iron/constraint/numeric.scala
+++ b/main/src/io/github/iltotore/iron/constraint/numeric.scala
@@ -51,7 +51,7 @@ object numeric:
 
     /**
      * Tests if the input is included in `(V1, V2)`
-     * 
+     *
      * @tparam V1 the lower bound, exclusive.
      * @tparam V2 the upper bound, exclusive.
      */

--- a/main/src/io/github/iltotore/iron/constraint/string.scala
+++ b/main/src/io/github/iltotore/iron/constraint/string.scala
@@ -83,23 +83,23 @@ object string:
   object Blank:
 
     given (Empty ==> Blank) = Implication()
-    
+
   object StartWith:
-    
+
     inline given [V <: String]: Constraint[String, StartWith[V]] with
 
-      override inline def test(value: String): Boolean = ${check('value, '{constValue[V]})}
+      override inline def test(value: String): Boolean = ${ check('value, '{ constValue[V] }) }
 
       override inline def message: String = "Should start with " + stringValue[V]
-    
+
     private def check(expr: Expr[String], prefixExpr: Expr[String])(using Quotes): Expr[Boolean] =
       (expr.value, prefixExpr.value) match
         case (Some(value), Some(prefix)) => Expr(value.startsWith(prefix))
-        case _ => '{$expr.startsWith($prefixExpr)}
+        case _                           => '{ $expr.startsWith($prefixExpr) }
 
   object EndWith:
 
-    inline given[V <: String]: Constraint[String, EndWith[V]] with
+    inline given [V <: String]: Constraint[String, EndWith[V]] with
 
       override inline def test(value: String): Boolean = ${ check('value, '{ constValue[V] }) }
 
@@ -108,10 +108,10 @@ object string:
     private def check(expr: Expr[String], prefixExpr: Expr[String])(using Quotes): Expr[Boolean] =
       (expr.value, prefixExpr.value) match
         case (Some(value), Some(prefix)) => Expr(value.endsWith(prefix))
-        case _ => '{ $expr.endsWith($prefixExpr) }
+        case _                           => '{ $expr.endsWith($prefixExpr) }
 
   object Match:
-    
+
     inline given [V <: String]: Constraint[String, Match[V]] with
 
       override inline def test(value: String): Boolean = ${ check('value, '{ constValue[V] }) }

--- a/main/src/io/github/iltotore/iron/conversion.scala
+++ b/main/src/io/github/iltotore/iron/conversion.scala
@@ -102,7 +102,15 @@ extension [A, C1](value: A :| C1)
     (value: A).refineOption[C2].map(_.assumeFurther[C1])
 
 extension [A, C1, C2](value: A :| C1 :| C2)
+
+  /**
+   * Transform `A :| C1 :| C2` to `A :| (C1 & C2)`
+   */
   inline def compose: A :| (C1 & C2) = (value: A).assume[C1 & C2]
 
 extension [A, C1, C2](value: A :| (C1 & C2))
+
+  /**
+   * Transform `A :| (C1 & C2)` to `A :| C1 :| C2`
+   */
   inline def decompose: A :| C1 :| C2 = (value: A).assume[C1].assume[C2]

--- a/main/src/io/github/iltotore/iron/internal/Validation.scala
+++ b/main/src/io/github/iltotore/iron/internal/Validation.scala
@@ -9,12 +9,11 @@ import Validation.*
 extension [L, R](validation: Validation[L, R])
 
   def accumulate[L2, R2](other: Validation[L2, R2]): Validation[L | L2, (R, R2)] = (validation, other) match
-    case (Valid(value), Valid(otherValue)) => Valid((value, otherValue))
-    case (Valid(_), Invalid(otherErrors)) => Invalid(otherErrors)
-    case (Invalid(errors), Valid(_)) => Invalid(errors)
+    case (Valid(value), Valid(otherValue))       => Valid((value, otherValue))
+    case (Valid(_), Invalid(otherErrors))        => Invalid(otherErrors)
+    case (Invalid(errors), Valid(_))             => Invalid(errors)
     case (Invalid(errors), Invalid(otherErrors)) => Invalid((errors ++ otherErrors).asInstanceOf)
 
   def map[R2](f: R => R2): Validation[L, R2] = validation match
-    case Valid(value) => Valid(f(value))
+    case Valid(value)    => Valid(f(value))
     case Invalid(errors) => Invalid(errors)
-  

--- a/main/src/io/github/iltotore/iron/macros/package.scala
+++ b/main/src/io/github/iltotore/iron/macros/package.scala
@@ -104,7 +104,7 @@ given FromExpr[String] with
 inline def assertCondition[A](inline input: A, inline cond: Boolean, inline message: String): Unit =
   ${ assertConditionImpl[A]('input, 'cond, 'message) }
 
-private def assertConditionImpl[A : Type](input: Expr[A], cond: Expr[Boolean], message: Expr[String])(using Quotes): Expr[Unit] =
+private def assertConditionImpl[A: Type](input: Expr[A], cond: Expr[Boolean], message: Expr[String])(using Quotes): Expr[Unit] =
 
   import quotes.reflect.*
 
@@ -184,7 +184,7 @@ private def isConstantImpl[A: Type](expr: Expr[A])(using Quotes): Expr[Boolean] 
 
 def compileTimeError(msg: String)(using Quotes): Nothing =
   quotes.reflect.report.errorAndAbort(
-  s"""|-- Constraint Error --------------------------------------------------------
-      |$msg
-      |----------------------------------------------------------------------------""".stripMargin
+    s"""|-- Constraint Error --------------------------------------------------------
+        |$msg
+        |----------------------------------------------------------------------------""".stripMargin
   )

--- a/main/src/io/github/iltotore/iron/macros/union.scala
+++ b/main/src/io/github/iltotore/iron/macros/union.scala
@@ -44,9 +44,9 @@ object union:
       tpe.dealias match
         case OrType(left, right) =>
           rec(left)
-          .accumulate(rec(right))
-          .map((leftResult, rightResult) => '{ $leftResult || $rightResult })
-            
+            .accumulate(rec(right))
+            .map((leftResult, rightResult) => '{ $leftResult || $rightResult })
+
         case t =>
           val implTpe = constraintTpe.appliedTo(List(aTpe, t))
 

--- a/main/src/io/github/iltotore/iron/package.scala
+++ b/main/src/io/github/iltotore/iron/package.scala
@@ -47,6 +47,15 @@ end IronType
 extension [A](value: A)
 
   /**
+   * Refine the given value at runtime, assuming the constraint holds.
+   *
+   * @param constraint the constraint to test with the value to refine.
+   * @return a constrained value, without performing constraint checks.
+   * @see [[autoRefine]], [[refine]].
+   */
+  inline def assume[B]: A :| B = value
+
+  /**
    * Refine the given value at runtime.
    *
    * @param constraint the constraint to test with the value to refine.
@@ -77,12 +86,3 @@ extension [A](value: A)
    */
   inline def refineOption[B](using inline constraint: Constraint[A, B]): Option[A :| B] =
     Option.when(constraint.test(value))(value)
-
-  /**
-   * Refine the given value at runtime, assuming the constraint holds.
-   *
-   * @param constraint the constraint to test with the value to refine.
-   * @return a constrained value, without performing constraint checks.
-   * @see [[autoRefine]], [[refine]].
-   */
-  inline def assume[B]: A :| B = value

--- a/zio/src/io/github/iltotore/iron/zio.scala
+++ b/zio/src/io/github/iltotore/iron/zio.scala
@@ -16,3 +16,14 @@ object zio:
     inline def refineValidation[C](using inline constraint: Constraint[A, C]): Validation[String, A :| C] =
       Validation.fromPredicateWith(constraint.message)(value.asInstanceOf[A :| C])(constraint.test(_))
 
+
+  extension [A, C1](value: A :| C1)
+
+    /**
+     * Refine the given value again applicatively at runtime, resulting in a [[Validation]].
+     *
+     * @param constraint the new constraint to test.
+     * @return a [[Valid]] containing this value as [[IronType]] or an [[Validation.Failure]] containing a [[NonEmptyChunk]] of error messages.
+     */
+    inline def refineFurtherValidation[C2](using inline constraint: Constraint[A, C2]): Validation[String, A :| (C1 & C2)] =
+      (value: A).refineValidation[C2].map(_.assumeFurther[C1])


### PR DESCRIPTION
Add `refineFurther` (and monadic variants) to enable fine-grained refinement of the same value. Here is the motivating example in docs:


```scala
type Username = DescribedAs[Alphanumeric, "Username should be alphanumeric"]
type Password = DescribedAs[
  Alphanumeric & MinLength[5] & Exists[Letter] & Exists[Digit],
  "Password should have at least 5 characters, be alphanumeric and contain at least one letter and one digit"
]

case class User(name: String :| Username, password: String :| Password)

def createUser(name: String, password: String): Either[String, User] =
  for
    validName     <- name.refineEither[Username]
    alphanumeric  <- password.refineEither[Alphanumeric]
    minLength     <- alphanumeric.refineFurtherEither[MinLength[5]]
    hasLetter     <- minLength.refineFurtherEither[Exists[Letter]]
    validPassword <- hasLetter.refineFurtherEither[Exists[Digit]]
  yield
    User(validName, validPassword)

createUser("Iltotore", "abc123") //Right(User("Iltotore", "abc123"))
createUser("Iltotore", "abc1") //Left("Should have a minimum length of 5")
createUser("Iltotore", "abcde") //Left("At least one element: (Should be a digit)")
createUser("Iltotore", "abc123  ") //Left("Should be alphanumeric")
```

Closes #106 

@GiGurra did I miss something or does it fulfill your need?