### PR TITLE
fix: Remove redundant restriction at compile-time

### DIFF
--- a/main/src/io/github/iltotore/iron/conversion.scala
+++ b/main/src/io/github/iltotore/iron/conversion.scala
@@ -16,7 +16,6 @@ import scala.language.implicitConversions
  * @note This method ensures that the value satisfies the constraint. If it doesn't or isn't evaluable at compile-time, the compilation is aborted.
  */
 implicit inline def autoRefine[A, C](inline value: A)(using inline constraint: Constraint[A, C]): A :| C =
-  inline if !macros.isConstant(value) then macros.nonConstantError(value)
   macros.assertCondition(value, constraint.test(value), constraint.message)
   IronType(value)
 

--- a/main/src/io/github/iltotore/iron/macros/package.scala
+++ b/main/src/io/github/iltotore/iron/macros/package.scala
@@ -133,27 +133,6 @@ private def assertConditionImpl[A: Type](input: Expr[A], cond: Expr[Boolean], me
   '{}
 
 /**
- * Throw compile-time error indicating that the given value is not constant.
- *
- * @param value the non-constant value, used in the error message.
- * @tparam A the type of `value`.
- */
-inline def nonConstantError[A](inline value: A): Nothing = ${ nonConstantErrorImpl('value) }
-
-private def nonConstantErrorImpl[A](expr: Expr[A])(using Quotes): Nothing =
-
-  import quotes.reflect.*
-
-  compileTimeError(
-    s"""Cannot refine non full inlined input at compile-time.
-       |To test a constraint at runtime, use the `refine` extension method.
-       |
-       |Note: Due to a Scala limitation, already-refined types cannot be tested at compile-time (unless proven by an `Implication`).
-       |
-       |${CYAN}Inlined input$RESET: ${expr.asTerm.show}""".stripMargin
-  )
-
-/**
  * Checks if the given value is constant (aka evaluable at compile time).
  *
  * @param value the value to test.


### PR DESCRIPTION
Should fix #122 

This now compiles:
```scala
opaque type FirstName = String :| True
object FirstName extends RefinedTypeOps[FirstName]
```
```scala
val rawName = "Raf"
val name = FirstName(rawName)
```

@antonkw, does it solve your problem?