### PR TITLE
Added support for BigDecimal and BigInt

### DIFF
--- a/main/src/io/github/iltotore/iron/compileTime.scala
+++ b/main/src/io/github/iltotore/iron/compileTime.scala
@@ -158,12 +158,31 @@ object compileTime:
     case Double => A & Double
 
   /**
+   * Polymorphic `ToLong`.
+   *
+   * @tparam A the constant type to cast.
+   */
+  type ToLong[A <: NumConstant] <: Long = A match
+    case Double => double.ToLong[A]
+    case Float  => float.ToLong[A]
+    case Int    => int.ToLong[A]
+    case Long   => A & Long
+
+  /**
    * Get the `Double` value of the given type.
    *
    * @tparam A the type to convert to `Double`.
    * @return the String representation of the given type. Equivalent to `constValue[ToDouble[A]]`.
    */
   transparent inline def doubleValue[A <: NumConstant]: Double = constValue[ToDouble[A]]
+
+  /**
+   * Get the `Long` value of the given type.
+   *
+   * @tparam A the type to convert to `Long`.
+   * @return the Long representation of the given type. Equivalent to `constValue[ToLong[A]]`.
+   */
+  transparent inline def longValue[A <: NumConstant]: Long = constValue[ToLong[A]]
 
   /**
    * Get the `String` value of the given type.

--- a/main/src/io/github/iltotore/iron/compileTime.scala
+++ b/main/src/io/github/iltotore/iron/compileTime.scala
@@ -10,10 +10,6 @@ import scala.quoted.*
  */
 object compileTime:
 
-  type Floating = Float | Double
-
-  type Integral = Int | Long
-
   type NumConstant = Int | Long | Float | Double
 
   /**

--- a/main/src/io/github/iltotore/iron/compileTime.scala
+++ b/main/src/io/github/iltotore/iron/compileTime.scala
@@ -10,7 +10,9 @@ import scala.quoted.*
  */
 object compileTime:
 
-  type IntConstant = Int | Long
+  type Floating = Float | Double
+
+  type Integral = Int | Long
 
   type NumConstant = Int | Long | Float | Double
 

--- a/main/src/io/github/iltotore/iron/compileTime.scala
+++ b/main/src/io/github/iltotore/iron/compileTime.scala
@@ -10,6 +10,8 @@ import scala.quoted.*
  */
 object compileTime:
 
+  type IntConstant = Int | Long
+
   type NumConstant = Int | Long | Float | Double
 
   /**

--- a/main/src/io/github/iltotore/iron/constraint/any.scala
+++ b/main/src/io/github/iltotore/iron/constraint/any.scala
@@ -167,19 +167,19 @@ object any:
 
   object StrictEqual extends StrictEqualLowPriority:
 
-    inline given [V <: NumConstant](using NotGiven[V =:= 0]): StrictEqualConstraint[BigDecimal, V] with
-      override inline def test(value: BigDecimal): Boolean = value == BigDecimal(doubleValue[V])
+    inline given [V <: NumConstant]: StrictEqualConstraint[BigDecimal, V] with
+      override inline def test(value: BigDecimal): Boolean =
+        value == (inline doubleValue[V] match
+          case 0.0   => numeric.bigDecimal0
+          case limit => BigDecimal(limit)
+        )
 
-    // specialized case avoids allocation per test
-    inline given StrictEqualConstraint[BigDecimal, 0] with
-      override inline def test(value: BigDecimal): Boolean = value == numeric.bigDecimal0
-
-    inline given [V <: NumConstant](using NotGiven[V =:= 0]): StrictEqualConstraint[BigInt, V] with
-      override inline def test(value: BigInt): Boolean = value == BigInt(longValue[V])
-
-    // specialized case avoids allocation per test
-    inline given StrictEqualConstraint[BigInt, 0] with
-      override inline def test(value: BigInt): Boolean = value == numeric.bigInt0
+    inline given [V <: NumConstant]: StrictEqualConstraint[BigInt, V] with
+      override inline def test(value: BigInt): Boolean =
+        value == (inline longValue[V] match
+          case 0L    => numeric.bigInt0
+          case limit => BigInt(limit)
+        )
 
   sealed trait StrictEqualLowPriority:
 

--- a/main/src/io/github/iltotore/iron/constraint/any.scala
+++ b/main/src/io/github/iltotore/iron/constraint/any.scala
@@ -181,6 +181,14 @@ object any:
           case limit => BigInt(limit)
         )
 
+    inline given jBigDecimal[V <: NumConstant]: StrictEqualConstraint[java.math.BigDecimal, V] with
+      override inline def test(value: java.math.BigDecimal): Boolean =
+        value == (inline if doubleValue[V] == 0.0 then java.math.BigDecimal.ZERO else java.math.BigDecimal(stringValue[V]))
+
+    inline given jBigInteger[V <: IntConstant]: StrictEqualConstraint[java.math.BigInteger, V] with
+      override inline def test(value: java.math.BigInteger): Boolean =
+        value == (inline if longValue[V] == 0L then java.math.BigInteger.ZERO else java.math.BigInteger(stringValue[V]))
+
   sealed trait StrictEqualLowPriority:
 
     protected trait StrictEqualConstraint[A, V] extends Constraint[A, StrictEqual[V]]:

--- a/main/src/io/github/iltotore/iron/constraint/any.scala
+++ b/main/src/io/github/iltotore/iron/constraint/any.scala
@@ -176,17 +176,17 @@ object any:
     inline given [V <: NumConstant]: StrictEqualConstraint[BigDecimal, V] with
       override inline def test(value: BigDecimal): Boolean = value == doubleValue[V]
 
-    inline given [V <: Integral]: StrictEqualConstraint[BigInt, V] with
+    inline given [V <: Int | Long]: StrictEqualConstraint[BigInt, V] with
       override inline def test(value: BigInt): Boolean = value == longValue[V]
 
-    inline given jBigDecimalDouble[V <: Floating]: StrictEqualConstraint[java.math.BigDecimal, V] with
+    inline given jBigDecimalDouble[V <: Float | Double]: StrictEqualConstraint[java.math.BigDecimal, V] with
       override inline def test(value: java.math.BigDecimal): Boolean =
         value == java.math.BigDecimal.valueOf(doubleValue[V])
 
-    inline given jBigDecimalLong[V <: Integral]: StrictEqualConstraint[java.math.BigDecimal, V] with
+    inline given jBigDecimalLong[V <: Int | Long]: StrictEqualConstraint[java.math.BigDecimal, V] with
       override inline def test(value: java.math.BigDecimal): Boolean =
         value == java.math.BigDecimal.valueOf(longValue[V])
 
-    inline given jBigInteger[V <: Integral]: StrictEqualConstraint[java.math.BigInteger, V] with
+    inline given jBigInteger[V <: Int | Long]: StrictEqualConstraint[java.math.BigInteger, V] with
       override inline def test(value: java.math.BigInteger): Boolean =
         value == java.math.BigInteger.valueOf(longValue[V])

--- a/main/src/io/github/iltotore/iron/constraint/any.scala
+++ b/main/src/io/github/iltotore/iron/constraint/any.scala
@@ -176,13 +176,17 @@ object any:
     inline given [V <: NumConstant]: StrictEqualConstraint[BigDecimal, V] with
       override inline def test(value: BigDecimal): Boolean = value == doubleValue[V]
 
-    inline given [V <: IntConstant]: StrictEqualConstraint[BigInt, V] with
+    inline given [V <: Integral]: StrictEqualConstraint[BigInt, V] with
       override inline def test(value: BigInt): Boolean = value == longValue[V]
 
-    inline given jBigDecimal[V <: NumConstant]: StrictEqualConstraint[java.math.BigDecimal, V] with
+    inline given jBigDecimalDouble[V <: Floating]: StrictEqualConstraint[java.math.BigDecimal, V] with
       override inline def test(value: java.math.BigDecimal): Boolean =
-        value == java.math.BigDecimal(stringValue[V])
+        value == java.math.BigDecimal.valueOf(doubleValue[V])
 
-    inline given jBigInteger[V <: IntConstant]: StrictEqualConstraint[java.math.BigInteger, V] with
+    inline given jBigDecimalLong[V <: Integral]: StrictEqualConstraint[java.math.BigDecimal, V] with
+      override inline def test(value: java.math.BigDecimal): Boolean =
+        value == java.math.BigDecimal.valueOf(longValue[V])
+
+    inline given jBigInteger[V <: Integral]: StrictEqualConstraint[java.math.BigInteger, V] with
       override inline def test(value: java.math.BigInteger): Boolean =
-        value == java.math.BigInteger(stringValue[V])
+        value == java.math.BigInteger.valueOf(longValue[V])

--- a/main/src/io/github/iltotore/iron/constraint/any.scala
+++ b/main/src/io/github/iltotore/iron/constraint/any.scala
@@ -173,11 +173,14 @@ object any:
     inline given [A, V]: StrictEqualConstraint[A, V] with
       override inline def test(value: A): Boolean = value == constValue[V]
 
-    inline given [V <: NumConstant]: StrictEqualConstraint[BigDecimal, V] with
-      override inline def test(value: BigDecimal): Boolean = value == doubleValue[V]
+    inline given bigDecimalDouble[V <: Float | Double]: StrictEqualConstraint[BigDecimal, V] with
+      override inline def test(value: BigDecimal): Boolean = value == BigDecimal(doubleValue[V])
+
+    inline given bigDecimalLong[V <: Int | Long]: StrictEqualConstraint[BigDecimal, V] with
+      override inline def test(value: BigDecimal): Boolean = value == BigDecimal(longValue[V])
 
     inline given [V <: Int | Long]: StrictEqualConstraint[BigInt, V] with
-      override inline def test(value: BigInt): Boolean = value == longValue[V]
+      override inline def test(value: BigInt): Boolean = value == BigInt(longValue[V])
 
     inline given jBigDecimalDouble[V <: Float | Double]: StrictEqualConstraint[java.math.BigDecimal, V] with
       override inline def test(value: java.math.BigDecimal): Boolean =

--- a/main/src/io/github/iltotore/iron/constraint/any.scala
+++ b/main/src/io/github/iltotore/iron/constraint/any.scala
@@ -165,7 +165,13 @@ object any:
      */
     given right[C1, C2, C3](using C1 ==> Not[C2], C1 ==> C3): (C1 ==> Xor[C2, C3]) = Implication()
 
-  object StrictEqual extends StrictEqualLowPriority:
+  object StrictEqual:
+
+    private trait StrictEqualConstraint[A, V] extends Constraint[A, StrictEqual[V]]:
+      override inline def message: String = "Should strictly equal to " + constValue[ToString[V]]
+
+    inline given [A, V]: StrictEqualConstraint[A, V] with
+      override inline def test(value: A): Boolean = value == constValue[V]
 
     inline given [V <: NumConstant]: StrictEqualConstraint[BigDecimal, V] with
       override inline def test(value: BigDecimal): Boolean = value == doubleValue[V]
@@ -180,11 +186,3 @@ object any:
     inline given jBigInteger[V <: IntConstant]: StrictEqualConstraint[java.math.BigInteger, V] with
       override inline def test(value: java.math.BigInteger): Boolean =
         value == java.math.BigInteger(stringValue[V])
-
-  sealed trait StrictEqualLowPriority:
-
-    protected trait StrictEqualConstraint[A, V] extends Constraint[A, StrictEqual[V]]:
-      override inline def message: String = "Should strictly equal to " + constValue[ToString[V]]
-
-    inline given [A, V]: StrictEqualConstraint[A, V] with
-      override inline def test(value: A): Boolean = value == constValue[V]

--- a/main/src/io/github/iltotore/iron/constraint/any.scala
+++ b/main/src/io/github/iltotore/iron/constraint/any.scala
@@ -168,7 +168,7 @@ object any:
   object StrictEqual:
 
     private trait StrictEqualConstraint[A, V] extends Constraint[A, StrictEqual[V]]:
-      override inline def message: String = "Should strictly equal to " + constValue[ToString[V]]
+      override inline def message: String = "Should strictly equal to " + stringValue[V]
 
     inline given [A, V]: StrictEqualConstraint[A, V] with
       override inline def test(value: A): Boolean = value == constValue[V]

--- a/main/src/io/github/iltotore/iron/constraint/any.scala
+++ b/main/src/io/github/iltotore/iron/constraint/any.scala
@@ -168,26 +168,18 @@ object any:
   object StrictEqual extends StrictEqualLowPriority:
 
     inline given [V <: NumConstant]: StrictEqualConstraint[BigDecimal, V] with
-      override inline def test(value: BigDecimal): Boolean =
-        value == (inline doubleValue[V] match
-          case 0.0   => numeric.bigDecimal0
-          case limit => BigDecimal(limit)
-        )
+      override inline def test(value: BigDecimal): Boolean = value == doubleValue[V]
 
     inline given [V <: IntConstant]: StrictEqualConstraint[BigInt, V] with
-      override inline def test(value: BigInt): Boolean =
-        value == (inline longValue[V] match
-          case 0L    => numeric.bigInt0
-          case limit => BigInt(limit)
-        )
+      override inline def test(value: BigInt): Boolean = value == longValue[V]
 
     inline given jBigDecimal[V <: NumConstant]: StrictEqualConstraint[java.math.BigDecimal, V] with
       override inline def test(value: java.math.BigDecimal): Boolean =
-        value == (inline if doubleValue[V] == 0.0 then java.math.BigDecimal.ZERO else java.math.BigDecimal(stringValue[V]))
+        value == java.math.BigDecimal(stringValue[V])
 
     inline given jBigInteger[V <: IntConstant]: StrictEqualConstraint[java.math.BigInteger, V] with
       override inline def test(value: java.math.BigInteger): Boolean =
-        value == (inline if longValue[V] == 0L then java.math.BigInteger.ZERO else java.math.BigInteger(stringValue[V]))
+        value == java.math.BigInteger(stringValue[V])
 
   sealed trait StrictEqualLowPriority:
 

--- a/main/src/io/github/iltotore/iron/constraint/any.scala
+++ b/main/src/io/github/iltotore/iron/constraint/any.scala
@@ -174,7 +174,7 @@ object any:
           case limit => BigDecimal(limit)
         )
 
-    inline given [V <: NumConstant]: StrictEqualConstraint[BigInt, V] with
+    inline given [V <: IntConstant]: StrictEqualConstraint[BigInt, V] with
       override inline def test(value: BigInt): Boolean =
         value == (inline longValue[V] match
           case 0L    => numeric.bigInt0

--- a/main/src/io/github/iltotore/iron/constraint/numeric.scala
+++ b/main/src/io/github/iltotore/iron/constraint/numeric.scala
@@ -11,9 +11,6 @@ import scala.util.NotGiven
  */
 object numeric:
 
-  private[iron] val bigDecimal0: BigDecimal = BigDecimal(0)
-  private[iron] val bigInt0: BigInt = BigInt(0)
-
   /**
    * Tests strict superiority.
    *
@@ -139,26 +136,18 @@ object numeric:
       override inline def test(value: Double): Boolean = value > doubleValue[V]
 
     inline given [V <: NumConstant]: GreaterConstraint[BigDecimal, V] with
-      override inline def test(value: BigDecimal): Boolean =
-        value > (inline doubleValue[V] match
-          case 0.0   => bigDecimal0
-          case limit => BigDecimal(limit)
-        )
+      override inline def test(value: BigDecimal): Boolean = value > doubleValue[V]
 
     inline given [V <: IntConstant]: GreaterConstraint[BigInt, V] with
-      override inline def test(value: BigInt): Boolean =
-        value > (inline longValue[V] match
-          case 0L    => bigInt0
-          case limit => BigInt(limit)
-        )
+      override inline def test(value: BigInt): Boolean = value > longValue[V]
 
     inline given jBigDecimal[V <: NumConstant]: GreaterConstraint[java.math.BigDecimal, V] with
       override inline def test(value: java.math.BigDecimal): Boolean =
-        value.compareTo(inline if doubleValue[V] == 0.0 then java.math.BigDecimal.ZERO else java.math.BigDecimal(stringValue[V])) > 0
+        value.compareTo(java.math.BigDecimal(stringValue[V])) > 0
 
     inline given jBigInteger[V <: IntConstant]: GreaterConstraint[java.math.BigInteger, V] with
       override inline def test(value: java.math.BigInteger): Boolean =
-        value.compareTo(inline if longValue[V] == 0L then java.math.BigInteger.ZERO else java.math.BigInteger(stringValue[V])) > 0
+        value.compareTo(java.math.BigInteger(stringValue[V])) > 0
 
     given [V1, V2](using V1 > V2 =:= true): (Greater[V1] ==> Greater[V2]) = Implication()
 
@@ -187,26 +176,18 @@ object numeric:
       override inline def test(value: Double): Boolean = value < doubleValue[V]
 
     inline given [V <: NumConstant]: LessConstraint[BigDecimal, V] with
-      override inline def test(value: BigDecimal): Boolean =
-        value < (inline doubleValue[V] match
-          case 0.0   => bigDecimal0
-          case limit => BigDecimal(limit)
-        )
+      override inline def test(value: BigDecimal): Boolean = value < doubleValue[V]
 
     inline given [V <: IntConstant]: LessConstraint[BigInt, V] with
-      override inline def test(value: BigInt): Boolean =
-        value < (inline longValue[V] match
-          case 0L    => bigInt0
-          case limit => BigInt(limit)
-        )
+      override inline def test(value: BigInt): Boolean = value < longValue[V]
 
     inline given jBigDecimal[V <: NumConstant]: LessConstraint[java.math.BigDecimal, V] with
       override inline def test(value: java.math.BigDecimal): Boolean =
-        value.compareTo(inline if doubleValue[V] == 0.0 then java.math.BigDecimal.ZERO else java.math.BigDecimal(stringValue[V])) < 0
+        value.compareTo(java.math.BigDecimal(stringValue[V])) < 0
 
     inline given jBigInteger[V <: IntConstant]: LessConstraint[java.math.BigInteger, V] with
       override inline def test(value: java.math.BigInteger): Boolean =
-        value.compareTo(inline if longValue[V] == 0L then java.math.BigInteger.ZERO else java.math.BigInteger(stringValue[V])) < 0
+        value.compareTo(java.math.BigInteger(stringValue[V])) < 0
 
     given [V1, V2](using V1 < V2 =:= true): (Less[V1] ==> Less[V2]) = Implication()
 

--- a/main/src/io/github/iltotore/iron/constraint/numeric.scala
+++ b/main/src/io/github/iltotore/iron/constraint/numeric.scala
@@ -178,23 +178,19 @@ object numeric:
     inline given [V <: NumConstant]: LessConstraint[Double, V] with
       override inline def test(value: Double): Boolean = value < doubleValue[V]
 
-    inline given [V <: NumConstant](using NotGiven[V =:= 0]): LessConstraint[BigDecimal, V] with
+    inline given [V <: NumConstant]: LessConstraint[BigDecimal, V] with
       override inline def test(value: BigDecimal): Boolean =
         value < (inline doubleValue[V] match
           case 0.0   => bigDecimal0
           case limit => BigDecimal(limit)
         )
 
-    inline given [V <: NumConstant](using NotGiven[V =:= 0]): LessConstraint[BigInt, V] with
+    inline given [V <: NumConstant]: LessConstraint[BigInt, V] with
       override inline def test(value: BigInt): Boolean =
         value < (inline longValue[V] match
           case 0L    => bigInt0
           case limit => BigInt(limit)
         )
-
-    // specialized case avoids allocation per test
-    inline given LessConstraint[BigInt, 0] with
-      override inline def test(value: BigInt): Boolean = value < bigInt0
 
     given [V1, V2](using V1 < V2 =:= true): (Less[V1] ==> Less[V2]) = Implication()
 

--- a/main/src/io/github/iltotore/iron/constraint/numeric.scala
+++ b/main/src/io/github/iltotore/iron/constraint/numeric.scala
@@ -152,6 +152,14 @@ object numeric:
           case limit => BigInt(limit)
         )
 
+    inline given jBigDecimal[V <: NumConstant]: GreaterConstraint[java.math.BigDecimal, V] with
+      override inline def test(value: java.math.BigDecimal): Boolean =
+        value.compareTo(inline if doubleValue[V] == 0.0 then java.math.BigDecimal.ZERO else java.math.BigDecimal(stringValue[V])) > 0
+
+    inline given jBigInteger[V <: IntConstant]: GreaterConstraint[java.math.BigInteger, V] with
+      override inline def test(value: java.math.BigInteger): Boolean =
+        value.compareTo(inline if longValue[V] == 0L then java.math.BigInteger.ZERO else java.math.BigInteger(stringValue[V])) > 0
+
     given [V1, V2](using V1 > V2 =:= true): (Greater[V1] ==> Greater[V2]) = Implication()
 
     given [V1, V2](using V1 > V2 =:= true): (StrictEqual[V1] ==> Greater[V2]) = Implication()
@@ -191,6 +199,14 @@ object numeric:
           case 0L    => bigInt0
           case limit => BigInt(limit)
         )
+
+    inline given jBigDecimal[V <: NumConstant]: LessConstraint[java.math.BigDecimal, V] with
+      override inline def test(value: java.math.BigDecimal): Boolean =
+        value.compareTo(inline if doubleValue[V] == 0.0 then java.math.BigDecimal.ZERO else java.math.BigDecimal(stringValue[V])) < 0
+
+    inline given jBigInteger[V <: IntConstant]: LessConstraint[java.math.BigInteger, V] with
+      override inline def test(value: java.math.BigInteger): Boolean =
+        value.compareTo(inline if longValue[V] == 0L then java.math.BigInteger.ZERO else java.math.BigInteger(stringValue[V])) < 0
 
     given [V1, V2](using V1 < V2 =:= true): (Less[V1] ==> Less[V2]) = Implication()
 

--- a/main/src/io/github/iltotore/iron/constraint/numeric.scala
+++ b/main/src/io/github/iltotore/iron/constraint/numeric.scala
@@ -4,10 +4,15 @@ import io.github.iltotore.iron.constraint.any.*
 import io.github.iltotore.iron.compileTime.*
 import io.github.iltotore.iron.{==>, Constraint, Implication}
 
+import scala.util.NotGiven
+
 /**
  * Number-related constraints.
  */
 object numeric:
+
+  private[iron] val bigDecimal0: BigDecimal = BigDecimal(0)
+  private[iron] val bigInt0: BigInt = BigInt(0)
 
   /**
    * Tests strict superiority.
@@ -133,6 +138,20 @@ object numeric:
     inline given [V <: NumConstant]: GreaterConstraint[Double, V] with
       override inline def test(value: Double): Boolean = value > doubleValue[V]
 
+    inline given [V <: NumConstant](using NotGiven[V =:= 0]): GreaterConstraint[BigDecimal, V] with
+      override inline def test(value: BigDecimal): Boolean = value > doubleValue[V]
+
+    // specialized case avoids allocation per test
+    inline given GreaterConstraint[BigDecimal, 0] with
+      override inline def test(value: BigDecimal): Boolean = value > bigDecimal0
+
+    inline given [V <: NumConstant](using NotGiven[V =:= 0]): GreaterConstraint[BigInt, V] with
+      override inline def test(value: BigInt): Boolean = value > longValue[V]
+
+    // specialized case avoids allocation per test
+    inline given GreaterConstraint[BigInt, 0] with
+      override inline def test(value: BigInt): Boolean = value > bigInt0
+
     given [V1, V2](using V1 > V2 =:= true): (Greater[V1] ==> Greater[V2]) = Implication()
 
     given [V1, V2](using V1 > V2 =:= true): (StrictEqual[V1] ==> Greater[V2]) = Implication()
@@ -158,6 +177,20 @@ object numeric:
 
     inline given [V <: NumConstant]: LessConstraint[Double, V] with
       override inline def test(value: Double): Boolean = value < doubleValue[V]
+
+    inline given [V <: NumConstant](using NotGiven[V =:= 0]): LessConstraint[BigDecimal, V] with
+      override inline def test(value: BigDecimal): Boolean = value < doubleValue[V]
+
+    // specialized case avoids allocation per test
+    inline given LessConstraint[BigDecimal, 0] with
+      override inline def test(value: BigDecimal): Boolean = value < bigDecimal0
+
+    inline given [V <: NumConstant](using NotGiven[V =:= 0]): LessConstraint[BigInt, V] with
+      override inline def test(value: BigInt): Boolean = value < longValue[V]
+
+    // specialized case avoids allocation per test
+    inline given LessConstraint[BigInt, 0] with
+      override inline def test(value: BigInt): Boolean = value < bigInt0
 
     given [V1, V2](using V1 < V2 =:= true): (Less[V1] ==> Less[V2]) = Implication()
 

--- a/main/src/io/github/iltotore/iron/constraint/numeric.scala
+++ b/main/src/io/github/iltotore/iron/constraint/numeric.scala
@@ -145,7 +145,7 @@ object numeric:
           case limit => BigDecimal(limit)
         )
 
-    inline given [V <: NumConstant]: GreaterConstraint[BigInt, V] with
+    inline given [V <: IntConstant]: GreaterConstraint[BigInt, V] with
       override inline def test(value: BigInt): Boolean =
         value > (inline longValue[V] match
           case 0L    => bigInt0
@@ -193,7 +193,7 @@ object numeric:
           case limit => BigDecimal(limit)
         )
 
-    inline given [V <: NumConstant]: LessConstraint[BigInt, V] with
+    inline given [V <: IntConstant]: LessConstraint[BigInt, V] with
       override inline def test(value: BigInt): Boolean =
         value < (inline longValue[V] match
           case 0L    => bigInt0

--- a/main/src/io/github/iltotore/iron/constraint/numeric.scala
+++ b/main/src/io/github/iltotore/iron/constraint/numeric.scala
@@ -138,19 +138,19 @@ object numeric:
     inline given [V <: NumConstant]: GreaterConstraint[Double, V] with
       override inline def test(value: Double): Boolean = value > doubleValue[V]
 
-    inline given [V <: NumConstant](using NotGiven[V =:= 0]): GreaterConstraint[BigDecimal, V] with
-      override inline def test(value: BigDecimal): Boolean = value > doubleValue[V]
+    inline given [V <: NumConstant]: GreaterConstraint[BigDecimal, V] with
+      override inline def test(value: BigDecimal): Boolean =
+        value > (inline doubleValue[V] match
+          case 0.0   => bigDecimal0
+          case limit => BigDecimal(limit)
+        )
 
-    // specialized case avoids allocation per test
-    inline given GreaterConstraint[BigDecimal, 0] with
-      override inline def test(value: BigDecimal): Boolean = value > bigDecimal0
-
-    inline given [V <: NumConstant](using NotGiven[V =:= 0]): GreaterConstraint[BigInt, V] with
-      override inline def test(value: BigInt): Boolean = value > longValue[V]
-
-    // specialized case avoids allocation per test
-    inline given GreaterConstraint[BigInt, 0] with
-      override inline def test(value: BigInt): Boolean = value > bigInt0
+    inline given [V <: NumConstant]: GreaterConstraint[BigInt, V] with
+      override inline def test(value: BigInt): Boolean =
+        value > (inline longValue[V] match
+          case 0L    => bigInt0
+          case limit => BigInt(limit)
+        )
 
     given [V1, V2](using V1 > V2 =:= true): (Greater[V1] ==> Greater[V2]) = Implication()
 
@@ -179,14 +179,18 @@ object numeric:
       override inline def test(value: Double): Boolean = value < doubleValue[V]
 
     inline given [V <: NumConstant](using NotGiven[V =:= 0]): LessConstraint[BigDecimal, V] with
-      override inline def test(value: BigDecimal): Boolean = value < doubleValue[V]
-
-    // specialized case avoids allocation per test
-    inline given LessConstraint[BigDecimal, 0] with
-      override inline def test(value: BigDecimal): Boolean = value < bigDecimal0
+      override inline def test(value: BigDecimal): Boolean =
+        value < (inline doubleValue[V] match
+          case 0.0   => bigDecimal0
+          case limit => BigDecimal(limit)
+        )
 
     inline given [V <: NumConstant](using NotGiven[V =:= 0]): LessConstraint[BigInt, V] with
-      override inline def test(value: BigInt): Boolean = value < longValue[V]
+      override inline def test(value: BigInt): Boolean =
+        value < (inline longValue[V] match
+          case 0L    => bigInt0
+          case limit => BigInt(limit)
+        )
 
     // specialized case avoids allocation per test
     inline given LessConstraint[BigInt, 0] with

--- a/main/src/io/github/iltotore/iron/constraint/numeric.scala
+++ b/main/src/io/github/iltotore/iron/constraint/numeric.scala
@@ -138,16 +138,20 @@ object numeric:
     inline given [V <: NumConstant]: GreaterConstraint[BigDecimal, V] with
       override inline def test(value: BigDecimal): Boolean = value > doubleValue[V]
 
-    inline given [V <: IntConstant]: GreaterConstraint[BigInt, V] with
+    inline given [V <: Integral]: GreaterConstraint[BigInt, V] with
       override inline def test(value: BigInt): Boolean = value > longValue[V]
 
-    inline given jBigDecimal[V <: NumConstant]: GreaterConstraint[java.math.BigDecimal, V] with
+    inline given jBigDecimalDouble[V <: Floating]: GreaterConstraint[java.math.BigDecimal, V] with
       override inline def test(value: java.math.BigDecimal): Boolean =
-        value.compareTo(java.math.BigDecimal(stringValue[V])) > 0
+        value.compareTo(java.math.BigDecimal.valueOf(doubleValue[V])) > 0
 
-    inline given jBigInteger[V <: IntConstant]: GreaterConstraint[java.math.BigInteger, V] with
+    inline given jBigDecimalLong[V <: Integral]: GreaterConstraint[java.math.BigDecimal, V] with
+      override inline def test(value: java.math.BigDecimal): Boolean =
+        value.compareTo(java.math.BigDecimal.valueOf(longValue[V])) > 0
+
+    inline given jBigInteger[V <: Integral]: GreaterConstraint[java.math.BigInteger, V] with
       override inline def test(value: java.math.BigInteger): Boolean =
-        value.compareTo(java.math.BigInteger(stringValue[V])) > 0
+        value.compareTo(java.math.BigInteger.valueOf(longValue[V])) > 0
 
     given [V1, V2](using V1 > V2 =:= true): (Greater[V1] ==> Greater[V2]) = Implication()
 
@@ -178,16 +182,20 @@ object numeric:
     inline given [V <: NumConstant]: LessConstraint[BigDecimal, V] with
       override inline def test(value: BigDecimal): Boolean = value < doubleValue[V]
 
-    inline given [V <: IntConstant]: LessConstraint[BigInt, V] with
+    inline given [V <: Integral]: LessConstraint[BigInt, V] with
       override inline def test(value: BigInt): Boolean = value < longValue[V]
 
-    inline given jBigDecimal[V <: NumConstant]: LessConstraint[java.math.BigDecimal, V] with
+    inline given jBigDecimalDouble[V <: Floating]: LessConstraint[java.math.BigDecimal, V] with
       override inline def test(value: java.math.BigDecimal): Boolean =
-        value.compareTo(java.math.BigDecimal(stringValue[V])) < 0
+        value.compareTo(java.math.BigDecimal.valueOf(doubleValue[V])) < 0
 
-    inline given jBigInteger[V <: IntConstant]: LessConstraint[java.math.BigInteger, V] with
+    inline given jBigDecimalLong[V <: Integral]: LessConstraint[java.math.BigDecimal, V] with
+      override inline def test(value: java.math.BigDecimal): Boolean =
+        value.compareTo(java.math.BigDecimal.valueOf(longValue[V])) < 0
+
+    inline given jBigInteger[V <: Integral]: LessConstraint[java.math.BigInteger, V] with
       override inline def test(value: java.math.BigInteger): Boolean =
-        value.compareTo(java.math.BigInteger(stringValue[V])) < 0
+        value.compareTo(java.math.BigInteger.valueOf(longValue[V])) < 0
 
     given [V1, V2](using V1 < V2 =:= true): (Less[V1] ==> Less[V2]) = Implication()
 

--- a/main/src/io/github/iltotore/iron/constraint/numeric.scala
+++ b/main/src/io/github/iltotore/iron/constraint/numeric.scala
@@ -135,11 +135,14 @@ object numeric:
     inline given [V <: NumConstant]: GreaterConstraint[Double, V] with
       override inline def test(value: Double): Boolean = value > doubleValue[V]
 
-    inline given [V <: NumConstant]: GreaterConstraint[BigDecimal, V] with
-      override inline def test(value: BigDecimal): Boolean = value > doubleValue[V]
+    inline given bigDecimalDouble[V <: Float | Double]: GreaterConstraint[BigDecimal, V] with
+      override inline def test(value: BigDecimal): Boolean = value > BigDecimal(doubleValue[V])
+
+    inline given bigDecimalLong[V <: Int | Long]: GreaterConstraint[BigDecimal, V] with
+      override inline def test(value: BigDecimal): Boolean = value > BigDecimal(longValue[V])
 
     inline given [V <: Int | Long]: GreaterConstraint[BigInt, V] with
-      override inline def test(value: BigInt): Boolean = value > longValue[V]
+      override inline def test(value: BigInt): Boolean = value > BigInt(longValue[V])
 
     inline given jBigDecimalDouble[V <: Float | Double]: GreaterConstraint[java.math.BigDecimal, V] with
       override inline def test(value: java.math.BigDecimal): Boolean =
@@ -179,11 +182,14 @@ object numeric:
     inline given [V <: NumConstant]: LessConstraint[Double, V] with
       override inline def test(value: Double): Boolean = value < doubleValue[V]
 
-    inline given [V <: NumConstant]: LessConstraint[BigDecimal, V] with
-      override inline def test(value: BigDecimal): Boolean = value < doubleValue[V]
+    inline given bigDecimalDouble[V <: Float | Double]: LessConstraint[BigDecimal, V] with
+      override inline def test(value: BigDecimal): Boolean = value < BigDecimal(doubleValue[V])
+
+    inline given bigDecimalLong[V <: Int | Long]: LessConstraint[BigDecimal, V] with
+      override inline def test(value: BigDecimal): Boolean = value < BigDecimal(longValue[V])
 
     inline given [V <: Int | Long]: LessConstraint[BigInt, V] with
-      override inline def test(value: BigInt): Boolean = value < longValue[V]
+      override inline def test(value: BigInt): Boolean = value < BigInt(longValue[V])
 
     inline given jBigDecimalDouble[V <: Float | Double]: LessConstraint[java.math.BigDecimal, V] with
       override inline def test(value: java.math.BigDecimal): Boolean =

--- a/main/src/io/github/iltotore/iron/constraint/numeric.scala
+++ b/main/src/io/github/iltotore/iron/constraint/numeric.scala
@@ -138,18 +138,18 @@ object numeric:
     inline given [V <: NumConstant]: GreaterConstraint[BigDecimal, V] with
       override inline def test(value: BigDecimal): Boolean = value > doubleValue[V]
 
-    inline given [V <: Integral]: GreaterConstraint[BigInt, V] with
+    inline given [V <: Int | Long]: GreaterConstraint[BigInt, V] with
       override inline def test(value: BigInt): Boolean = value > longValue[V]
 
-    inline given jBigDecimalDouble[V <: Floating]: GreaterConstraint[java.math.BigDecimal, V] with
+    inline given jBigDecimalDouble[V <: Float | Double]: GreaterConstraint[java.math.BigDecimal, V] with
       override inline def test(value: java.math.BigDecimal): Boolean =
         value.compareTo(java.math.BigDecimal.valueOf(doubleValue[V])) > 0
 
-    inline given jBigDecimalLong[V <: Integral]: GreaterConstraint[java.math.BigDecimal, V] with
+    inline given jBigDecimalLong[V <: Int | Long]: GreaterConstraint[java.math.BigDecimal, V] with
       override inline def test(value: java.math.BigDecimal): Boolean =
         value.compareTo(java.math.BigDecimal.valueOf(longValue[V])) > 0
 
-    inline given jBigInteger[V <: Integral]: GreaterConstraint[java.math.BigInteger, V] with
+    inline given jBigInteger[V <: Int | Long]: GreaterConstraint[java.math.BigInteger, V] with
       override inline def test(value: java.math.BigInteger): Boolean =
         value.compareTo(java.math.BigInteger.valueOf(longValue[V])) > 0
 
@@ -182,18 +182,18 @@ object numeric:
     inline given [V <: NumConstant]: LessConstraint[BigDecimal, V] with
       override inline def test(value: BigDecimal): Boolean = value < doubleValue[V]
 
-    inline given [V <: Integral]: LessConstraint[BigInt, V] with
+    inline given [V <: Int | Long]: LessConstraint[BigInt, V] with
       override inline def test(value: BigInt): Boolean = value < longValue[V]
 
-    inline given jBigDecimalDouble[V <: Floating]: LessConstraint[java.math.BigDecimal, V] with
+    inline given jBigDecimalDouble[V <: Float | Double]: LessConstraint[java.math.BigDecimal, V] with
       override inline def test(value: java.math.BigDecimal): Boolean =
         value.compareTo(java.math.BigDecimal.valueOf(doubleValue[V])) < 0
 
-    inline given jBigDecimalLong[V <: Integral]: LessConstraint[java.math.BigDecimal, V] with
+    inline given jBigDecimalLong[V <: Int | Long]: LessConstraint[java.math.BigDecimal, V] with
       override inline def test(value: java.math.BigDecimal): Boolean =
         value.compareTo(java.math.BigDecimal.valueOf(longValue[V])) < 0
 
-    inline given jBigInteger[V <: Integral]: LessConstraint[java.math.BigInteger, V] with
+    inline given jBigInteger[V <: Int | Long]: LessConstraint[java.math.BigInteger, V] with
       override inline def test(value: java.math.BigInteger): Boolean =
         value.compareTo(java.math.BigInteger.valueOf(longValue[V])) < 0
 

--- a/main/test/src/io/github/iltotore/iron/testing/AnySuite.scala
+++ b/main/test/src/io/github/iltotore/iron/testing/AnySuite.scala
@@ -43,5 +43,13 @@ object AnySuite extends TestSuite:
     test("strictEqual") {
       test - 0.assertRefine[StrictEqual[0]]
       test - 1.assertNotRefine[StrictEqual[0]]
+      test - BigDecimal(0).assertRefine[StrictEqual[0]]
+      test - BigDecimal(1).assertNotRefine[StrictEqual[0]]
+      test - BigInt(0).assertRefine[StrictEqual[0]]
+      test - BigInt(1).assertNotRefine[StrictEqual[0]]
+      test - java.math.BigDecimal("0").assertRefine[StrictEqual[0]]
+      test - java.math.BigDecimal("1").assertNotRefine[StrictEqual[0]]
+      test - java.math.BigInteger("0").assertRefine[StrictEqual[0]]
+      test - java.math.BigInteger("1").assertNotRefine[StrictEqual[0]]
     }
   }

--- a/main/test/src/io/github/iltotore/iron/testing/NumericSuite.scala
+++ b/main/test/src/io/github/iltotore/iron/testing/NumericSuite.scala
@@ -11,6 +11,14 @@ object NumericSuite extends TestSuite:
     test("greater") {
       test - 0.assertNotRefine[Greater[0]]
       test - 1.assertRefine[Greater[0]]
+      test - BigDecimal(0).assertNotRefine[Greater[0]]
+      test - BigDecimal(1).assertRefine[Greater[0]]
+      test - BigInt(0).assertNotRefine[Greater[0]]
+      test - BigInt(1).assertRefine[Greater[0]]
+      test - java.math.BigDecimal("0").assertNotRefine[Greater[0]]
+      test - java.math.BigDecimal("1").assertRefine[Greater[0]]
+      test - java.math.BigInteger("0").assertNotRefine[Greater[0]]
+      test - java.math.BigInteger("1").assertRefine[Greater[0]]
     }
 
     test("greaterEqual") {
@@ -22,6 +30,14 @@ object NumericSuite extends TestSuite:
     test("less") {
       test - 0.assertNotRefine[Less[0]]
       test - -1.assertRefine[Less[0]]
+      test - BigDecimal(0).assertNotRefine[Less[0]]
+      test - BigDecimal(-1).assertRefine[Less[0]]
+      test - BigInt(0).assertNotRefine[Less[0]]
+      test - BigInt(-1).assertRefine[Less[0]]
+      test - java.math.BigDecimal("0").assertNotRefine[Less[0]]
+      test - java.math.BigDecimal("-1").assertRefine[Less[0]]
+      test - java.math.BigInteger("0").assertNotRefine[Less[0]]
+      test - java.math.BigInteger("-1").assertRefine[Less[0]]
     }
 
     test("lessEqual") {


### PR DESCRIPTION
Fix for #132.

I could not get compile time checking to work using macros and so removed them. Any suggestions?

**Macro**
```scala
    def testBigInt(e1: Expr[BigInt], e2: Expr[Long])(using Quotes): Expr[Boolean] = 
      '{ $e1 > BigInt($e2) }

    def testBigInt0(e1: Expr[BigInt])(using Quotes): Expr[Boolean] = 
      '{ $e1 > bigInt0 }
```
**Error**
```
[error]  9 |  val x: BigInt :| Greater[0] = BigInt(1)
[error]    |                                ^^^^^^^^^
[error]    |-- Constraint Error --------------------------------------------------------
[error]    |Cannot refine value at compile-time because the predicate cannot be evaluated.
[error]    |This is likely because the condition or the input value isn't fully inlined.
[error]    |
[error]    |To test a constraint at runtime, use the `refined` extension method.
[error]    |
[error]    |Inlined input: scala.BigInt.apply(1)
[error]    |Inlined condition: {
[error]    |  val value$proxy2: scala.math.BigInt = scala.BigInt.apply(1)
[error]    |
[error]    |  (value$proxy2.compare(io.github.iltotore.iron.constraint.numeric.inline$bigInt0).>(0): scala.Boolean)
[error]    |}
[error]    |Message: Should be greater than 0
[error]    |----------------------------------------------------------------------------
[error]    |----------------------------------------------------------------------------
[error]    |Inline stack trace
[error]    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
[error]    |This location contains code that was inlined from NumericSuite.scala:9
[error] 19 |  macros.assertCondition(value, constraint.test(value), constraint.message)
[error]    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]     ----------------------------------------------------------------------------
[error] one error found
```