### PR TITLE
Fix implicits priority

### DIFF
--- a/scalacheck/src/io/github/iltotore/iron/scalacheck/all.scala
+++ b/scalacheck/src/io/github/iltotore/iron/scalacheck/all.scala
@@ -1,7 +1,6 @@
 package io.github.iltotore.iron.scalacheck
 
-object all:
-  export any.given
+object all extends AnyArbitrary:
   export char.given
   export collection.given
   export numeric.given

--- a/scalacheck/src/io/github/iltotore/iron/scalacheck/any.scala
+++ b/scalacheck/src/io/github/iltotore/iron/scalacheck/any.scala
@@ -8,10 +8,12 @@ import org.scalacheck.Arbitrary.arbitrary
 
 import scala.compiletime.constValue
 
-object any extends LowPriorityArbitrary:
+object any extends AnyArbitrary
+
+trait AnyArbitrary extends LowPriorityArbitrary:
 
   inline given strictEqual[A, V <: A]: Arbitrary[A :| StrictEqual[V]] = Arbitrary(Gen.oneOf(Seq(constValue[V]))).asInstanceOf
-  
+
   inline given union[A, C](using IsUnion[C]): Arbitrary[A :| C] = Arbitrary(unionGen[A, C])
 
 trait LowPriorityArbitrary extends LowPriorityArbitrary2:

--- a/scalacheck/test/src/io/github/iltotore/iron/scalacheck/CollectionSuite.scala
+++ b/scalacheck/test/src/io/github/iltotore/iron/scalacheck/CollectionSuite.scala
@@ -22,7 +22,7 @@ object CollectionSuite extends TestSuite:
     }
     test("empty") {
       test("seq") - testGen[Seq[Boolean], Empty]
-      test("string") - testGen[Seq[Boolean], Empty]
+      test("string") - testGen[String, Empty]
     }
     test("contain") {
       test("seq") - testGen[Seq[Boolean], Contain[true]]

--- a/scalacheck/test/src/io/github/iltotore/iron/scalacheck/ImplicitsOrderingSuite.scala
+++ b/scalacheck/test/src/io/github/iltotore/iron/scalacheck/ImplicitsOrderingSuite.scala
@@ -1,0 +1,11 @@
+package io.github.iltotore.iron.scalacheck
+
+import io.github.iltotore.iron.constraint.all.*
+import io.github.iltotore.iron.scalacheck.all.given
+import utest.*
+
+object ImplicitsOrderingSuite extends TestSuite:
+
+  val tests: Tests = Tests {
+    test("should resolve implicits using all.given import") - testGen[String, Empty]
+  }


### PR DESCRIPTION
I tried to use scalacheck module with importing `io.github.iltotore.iron.scalacheck.all.given` - but I received the following error:

```
[E] [E1] scalacheck/test/src/io/github/iltotore/iron/scalacheck/ImplicitsOrderingSuite.scala:10:85
[E]      Ambiguous given instances: both given instance fallback in object all and given instance equivalence in object all match type org.scalacheck.Arbitrary[
[E]        io.github.iltotore.iron.IronType[String,
[E]          io.github.iltotore.iron.constraint.all.Empty]
[E]      ] of parameter arb of method testGen in package io.github.iltotore.iron.scalacheck
[E]      L10:     test("should resolve implicits using all.given import") - testGen[String, Empty]
[E]                                                                                               ^
[E] scalacheck/test/src/io/github/iltotore/iron/scalacheck/ImplicitsOrderingSuite.scala: L10 [E1]
```

I think this is because export statements remove the implicit scope ordering. I fixed this by extending the trait - so the regular way it was done pre scala 3.