### PR TITLE
Add arbitraries for not empty collection/string which do not ever fail to generate value

### DIFF
--- a/scalacheck/src/io/github/iltotore/iron/scalacheck/collection.scala
+++ b/scalacheck/src/io/github/iltotore/iron/scalacheck/collection.scala
@@ -63,3 +63,5 @@ object collection:
         init <- Gen.containerOf[CC, A](arb.arbitrary)
       yield (buildable.builder ++= evt(init) += constrainedLast ).result()
     ).asInstanceOf
+
+  inline given notEmptyCollection[CC, A](using evb: Buildable[A, CC], ev2: CC => Iterable[A], arb: Arbitrary[A]): Arbitrary[CC :| Not[Empty]] = Arbitrary(Gen.nonEmptyBuildableOf[CC, A](arb.arbitrary)).asInstanceOf

--- a/scalacheck/src/io/github/iltotore/iron/scalacheck/string.scala
+++ b/scalacheck/src/io/github/iltotore/iron/scalacheck/string.scala
@@ -1,6 +1,7 @@
 package io.github.iltotore.iron.scalacheck
 
 import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.collection.Empty
 import io.github.iltotore.iron.constraint.string.*
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Gen.Choose
@@ -8,7 +9,8 @@ import org.scalacheck.Gen.Choose
 import scala.compiletime.constValue
 
 object string:
-
+  inline given notEmptyString: Arbitrary[String :| Not[Empty]] = collection.notEmptyCollection[String, Char]
+  
   inline given startWith[V <: String]: Arbitrary[String :| StartWith[V]] =
     Arbitrary(Gen.asciiStr.map(constValue[V] + _)).asInstanceOf
 

--- a/scalacheck/test/src/io/github/iltotore/iron/scalacheck/CollectionSuite.scala
+++ b/scalacheck/test/src/io/github/iltotore/iron/scalacheck/CollectionSuite.scala
@@ -3,9 +3,7 @@ package io.github.iltotore.iron.scalacheck
 import io.github.iltotore.iron.*
 import io.github.iltotore.iron.constraint.all.*
 import io.github.iltotore.iron.constraint.numeric.*
-import io.github.iltotore.iron.scalacheck.any.given
-import io.github.iltotore.iron.scalacheck.collection.given
-import io.github.iltotore.iron.scalacheck.numeric.given
+import io.github.iltotore.iron.scalacheck.all.given
 import org.scalacheck.*
 import utest.*
 
@@ -23,6 +21,7 @@ object CollectionSuite extends TestSuite:
     test("empty") {
       test("seq") - testGen[Seq[Boolean], Empty]
       test("string") - testGen[String, Empty]
+      test("not empty") - testGen[Seq[Boolean], Not[Empty]]
     }
     test("contain") {
       test("seq") - testGen[Seq[Boolean], Contain[true]]

--- a/scalacheck/test/src/io/github/iltotore/iron/scalacheck/StringSuite.scala
+++ b/scalacheck/test/src/io/github/iltotore/iron/scalacheck/StringSuite.scala
@@ -1,6 +1,7 @@
 package io.github.iltotore.iron.scalacheck
 
 import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.collection.Empty
 import io.github.iltotore.iron.constraint.string.*
 import io.github.iltotore.iron.scalacheck.string.given
 import org.scalacheck.*
@@ -11,4 +12,5 @@ object StringSuite extends TestSuite:
   val tests: Tests = Tests {
     test("startWith") - testGen[String, StartWith["abc"]]
     test("endWith") - testGen[String, EndWith["abc"]]
+    test("not empty string") - testGen[String, Not[Empty]]
   }


### PR DESCRIPTION
I've observed, that generation of `String :| Not[Empty]` tends to fail to generate value from time to time (even up to 1.5% from my tests) <- because the generator used underneath from time to time selects 0 size for collection. 

This has caused some flaky tests for us when we had many such values generated and combined - then the probability of failing increases to `1 - 0.985^n` where n is number of values combined.

Scalacheck has built in function `Gen.nonEmptyBuildableOf` which can be used here. Not Empty case may be the most useful `Length[X]` case so it makes sense IMHO to optimise here. Similar thing is done in refined.