### PR TITLE
Add `iron-borer` integration module

### DIFF
--- a/borer/src/io/github/iltotore/iron/borer.scala
+++ b/borer/src/io/github/iltotore/iron/borer.scala
@@ -1,0 +1,24 @@
+package io.github.iltotore.iron
+
+import io.bullet.borer.{Encoder, Decoder}
+
+/**
+ * Automatic construction of borer [[Encoder]] and [[Decoder]] instances for refined types.
+ */
+object borer:
+
+  inline given [A, B](using inline encoder: Encoder[A]): Encoder[A :| B] =
+    encoder.asInstanceOf[Encoder[A :| B]]
+
+  inline given [A, B](using inline decoder: Decoder[A], inline constraint: Constraint[A, B]): Decoder[A :| B] =
+    Decoder { r =>
+      decoder.read(r).refineEither match
+        case Left(msg) => r.validationFailure(msg)
+        case Right(x)  => x
+    }
+
+  inline given [T](using m: RefinedTypeOps.Mirror[T], ev: Encoder[m.IronType]): Encoder[T] =
+    ev.asInstanceOf[Encoder[T]]
+
+  inline given [T](using m: RefinedTypeOps.Mirror[T], ev: Decoder[m.IronType]): Decoder[T] =
+    ev.asInstanceOf[Decoder[T]]

--- a/borer/test/src/io/github/iltotore/iron/BorerSuite.scala
+++ b/borer/test/src/io/github/iltotore/iron/BorerSuite.scala
@@ -1,0 +1,31 @@
+package io.github.iltotore.iron
+
+import io.github.iltotore.iron.constraint.all.*
+import io.github.iltotore.iron.borer.given
+import utest.*
+import io.bullet.borer.{Encoder, Json}
+
+object BorerSuite extends TestSuite:
+
+  val tests: Tests = Tests {
+
+    test("opaque alias encoding") {
+      Json.encode(Temperature(15.0)).toUtf8String ==> "15.0"
+    }
+
+    test("opaque alias decoding") {
+      Json.decode("15.0".getBytes).to[Temperature].valueEither ==> Right(Temperature(15.0))
+      Json.decode("-15.0".getBytes).to[Temperature].valueEither.left.map(_.getMessage) ==>
+        Left("Should be strictly positive (input position 0)")
+    }
+
+    test("transparent alias encoding") {
+      Json.encode(15.0:Moisture).toUtf8String ==> "15.0"
+    }
+
+    test("transparent alias decoding") {
+      Json.decode("15.0".getBytes).to[Moisture].valueEither ==> Right(15.0:Moisture)
+      Json.decode("-15.0".getBytes).to[Moisture].valueEither.left.map(_.getMessage) ==>
+        Left("Should be strictly positive (input position 0)")
+    }
+  }

--- a/borer/test/src/io/github/iltotore/iron/RefinedOpsTypes.scala
+++ b/borer/test/src/io/github/iltotore/iron/RefinedOpsTypes.scala
@@ -1,0 +1,13 @@
+package io.github.iltotore.iron
+
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.numeric.Positive
+
+/**
+ * We declare test types here, in a separate file, in order to make the opaque aliases truly opaque.
+ */
+opaque type Temperature = Double :| Positive
+object Temperature extends RefinedTypeOps[Double, Positive, Temperature]
+
+type Moisture = Double :| Positive
+object Moisture extends RefinedTypeOps.Transparent[Moisture]

--- a/build.sc
+++ b/build.sc
@@ -138,6 +138,7 @@ object docs extends BaseModule {
     ".*com.monovore.decline.*" -> ("scaladoc3", "https://javadoc.io/doc/com.monovore/decline_3/latest/"),
     ".*doobie.*" -> ("scaladoc3", "https://www.javadoc.io/doc/org.tpolecat/doobie-core_3/latest/"),
     ".*com.github.plokhotnyuk.jsoniter_scala.core.*" -> ("scaladoc3", "https://www.javadoc.io/doc/com.github.plokhotnyuk.jsoniter-scala/jsoniter-scala-core_3/latest/"),
+    ".*io.bullet.borer.*" -> ("scaladoc3", "https://javadoc.io/doc/io.bullet/borer-core_3/latest/"),
     ".*org.scalacheck.*" -> ("scaladoc3", "https://javadoc.io/doc/org.scalacheck/scalacheck_3/latest/"),
     ".*skunk.*" -> ("scaladoc3", "https://javadoc.io/doc/org.tpolecat/skunk-docs_3/latest/"),
     ".*upickle.core.*" -> ("scaladoc3", "https://javadoc.io/doc/com.lihaoyi/upickle-core_3/latest/"),
@@ -392,6 +393,19 @@ object jsoniter extends SubModule {
   object test extends Tests {
     def compileIvyDeps = Agg(jsoniterMacros)
   }
+}
+
+object borer extends SubModule {
+
+  def artifactName = "iron-borer"
+
+  def ivyDeps = Agg(
+    ivy"io.bullet::borer-core::1.13.0"
+  )
+
+  object js extends JSCrossModule
+
+  object test extends Tests
 }
 
 object skunk extends SubModule {

--- a/build.sc
+++ b/build.sc
@@ -244,6 +244,18 @@ object examples extends Module {
       ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:$jsoniterVersion"
     )
   }
+
+  object borerSerialization extends ScalaModule with ScalafmtModule {
+
+    def scalaVersion = versions.scala
+
+    def moduleDeps = Seq(main, borer)
+
+    def ivyDeps = Agg(
+      ivy"io.bullet::borer-core::1.13.0",
+      ivy"io.bullet::borer-derivation::1.13.0"
+    )
+  }
 }
 
 trait SubModule extends BaseModule {

--- a/examples/borerSerialization/README.md
+++ b/examples/borerSerialization/README.md
@@ -1,0 +1,25 @@
+# Small Demo of borer integration
+                                  
+This example shows how to integrate _iron_ with [borer](https://sirthias.github.io/borer/).
+
+After having added `"io.github.iltotore" %% "iron-borer" % "<version>"` as a dependency you can say this:
+
+```scala
+import io.github.iltotore.iron.borer.given
+```
+
+With this import in place all refined types `T` automatically have _borer_ `Encoder[T]` and `Decoder[T]`
+instances available, as long as the respective Encoders and Decoders for the (unrefined) underlying types are already
+`given`.
+
+If a refinement error is triggered during decoding because the decoded value doesn't match the refinement condition(s)
+decoding will fail with a `Borer.Error.ValidationFailure`.
+
+
+## Run the example
+
+Use the following command (in the Iron project root directory) to run the example:
+
+```sh
+mill examples.borerSerialization.run
+```

--- a/examples/borerSerialization/src/io/github/iltotore/iron/formBorer/Account.scala
+++ b/examples/borerSerialization/src/io/github/iltotore/iron/formBorer/Account.scala
@@ -1,0 +1,25 @@
+package io.github.iltotore.iron.formBorer
+
+import io.bullet.borer.Codec
+import io.bullet.borer.derivation.MapBasedCodecs
+import io.github.iltotore.iron.constraint.all.*
+import io.github.iltotore.iron.{*, given}
+import io.github.iltotore.iron.borer.given // this enables borer <-> iron integration
+
+type Username = (Alphanumeric & MinLength[3] & MaxLength[10]) DescribedAs
+  "Username should be alphanumeric and have a length between 3 and 10"
+
+type Password = (Match["[A-Za-z].*[0-9]|[0-9].*[A-Za-z]"] & MinLength[6] & MaxLength[20]) DescribedAs
+  "Password must contain at least a letter, a digit and have a length between 6 and 20"
+
+type Age = Greater[0] DescribedAs
+  "Age should be strictly positive"
+
+case class Account(
+    name: String :| Username,
+    password: String :| Password,
+    age: Int :| Age
+)
+
+object Account:
+  given Codec[Account] = MapBasedCodecs.deriveCodec

--- a/examples/borerSerialization/src/io/github/iltotore/iron/formBorer/main.scala
+++ b/examples/borerSerialization/src/io/github/iltotore/iron/formBorer/main.scala
@@ -1,0 +1,31 @@
+package io.github.iltotore.iron.formBorer
+
+import io.bullet.borer.{Borer, Json}
+import io.github.iltotore.iron.{*, given}
+
+@main def main: Unit =
+
+  val account = Account(
+    name = "matt",
+    password = "bar123",
+    age = 42
+  )
+
+  val okValidEncoding = """{"name":"matt","password":"bar123","age":42}"""
+  val invalidEncoding = """{"name":"matt","password":"bar","age":42}"""
+
+  val encoding = Json.encode(account).toUtf8String
+  println(encoding)
+  assert(encoding == okValidEncoding)
+
+  val decoding = Json.decode(okValidEncoding.getBytes).to[Account].valueEither
+  println(decoding)
+  assert(decoding == Right(account))
+
+  val decoding2 = Json.decode(invalidEncoding.getBytes).to[Account].valueEither
+  decoding2 match {
+    case Left(e: Borer.Error.ValidationFailure[_]) =>
+      // "Password must contain at least a letter, a digit and have a length between 6 and 20 (input position 26)"
+      println(e.getMessage)
+    case _ => throw new IllegalStateException
+  }


### PR DESCRIPTION
This adds a new module (`iron-borer`) providing automatic refined type codec construction for the `CBOR` and `JSON` serialization library [borer](https://sirthias.github.io/borer/).
It also adds a new example module showcasing the integration.

This is my first contribution to iron, so please let me know if anything is off!

And thank you for iron!
It's an awesome addition to the Scala 3 ecosystem.
