### PR TITLE
feat: Better diagnostics

### DIFF
--- a/main/src/io/github/iltotore/iron/macros/ReflectUtil.scala
+++ b/main/src/io/github/iltotore/iron/macros/ReflectUtil.scala
@@ -100,7 +100,7 @@ class ReflectUtil[Q <: Quotes & Singleton](using val _quotes: Q):
      * @param firstLineIdent the identation of the first line
      * @return a pretty-formatted [[String]] representation of this failure
      */
-    def prettyPrint(bodyIdent: Int = 0, firstLineIdent: Int = 0): String =
+    def prettyPrint(bodyIdent: Int = 0, firstLineIdent: Int = 0)(using Printer[Tree]): String =
       val unindented = this match
         case NotInlined(term) => s"Term not inlined: ${term.show}"
         case DefinitionNotInlined(name) => s"Definition not inlined: $name. Only vals and zero-arg def can be inlined."
@@ -158,8 +158,6 @@ class ReflectUtil[Q <: Quotes & Singleton](using val _quotes: Q):
         case Unknown => "Unknown reason"
 
       " " * firstLineIdent + unindented.replaceAll("(\r\n|\n|\r)", "$1" + " " * bodyIdent)
-
-    override def toString: String = prettyPrint()
 
   object ExprDecoder:
 

--- a/main/src/io/github/iltotore/iron/macros/package.scala
+++ b/main/src/io/github/iltotore/iron/macros/package.scala
@@ -49,35 +49,6 @@ private def assertConditionImpl[A: Type](input: Expr[A], cond: Expr[Boolean], me
                          |${MAGENTA}Message$RESET: $messageValue""".stripMargin)
   '{}
 
-/**
- * Checks if the given value is constant (aka evaluable at compile time).
- *
- * @param value the value to test.
- * @tparam A the type of `value`.
- * @return `true` if the given value is constant, `false` otherwise.
- */
-inline def isConstant[A](inline value: A): Boolean = ${ isConstantImpl('{ value }) }
-
-private def isConstantImpl[A: Type](expr: Expr[A])(using Quotes): Expr[Boolean] =
-
-  import quotes.reflect.*
-
-  val aType = TypeRepr.of[A]
-
-  val result: Boolean =
-    if aType <:< TypeRepr.of[Boolean] then expr.asExprOf[Boolean].value.isDefined
-    else if aType <:< TypeRepr.of[Byte] then expr.asExprOf[Byte].value.isDefined
-    else if aType <:< TypeRepr.of[Short] then expr.asExprOf[Short].value.isDefined
-    else if aType <:< TypeRepr.of[Int] then expr.asExprOf[Int].value.isDefined
-    else if aType <:< TypeRepr.of[Long] then expr.asExprOf[Long].value.isDefined
-    else if aType <:< TypeRepr.of[Float] then expr.asExprOf[Float].value.isDefined
-    else if aType <:< TypeRepr.of[Double] then expr.asExprOf[Double].value.isDefined
-    else if aType <:< TypeRepr.of[Char] then expr.asExprOf[Char].value.isDefined
-    else if aType <:< TypeRepr.of[String] then expr.asExprOf[String].value.isDefined
-    else false
-
-  Expr(result)
-
 def compileTimeError(msg: String)(using Quotes): Nothing =
   quotes.reflect.report.errorAndAbort(
     s"""|-- Constraint Error --------------------------------------------------------

--- a/main/src/io/github/iltotore/iron/macros/package.scala
+++ b/main/src/io/github/iltotore/iron/macros/package.scala
@@ -17,6 +17,9 @@ inline def assertCondition[A](inline input: A, inline cond: Boolean, inline mess
 private def assertConditionImpl[A: Type](input: Expr[A], cond: Expr[Boolean], message: Expr[String])(using Quotes): Expr[Unit] =
 
   import quotes.reflect.*
+
+  given Printer[Tree] = Printer.TreeAnsiCode
+
   val rflUtil = reflectUtil(using quotes)
   import rflUtil.*
 
@@ -31,10 +34,10 @@ private def assertConditionImpl[A: Type](input: Expr[A], cond: Expr[Boolean], me
            |
            |To test a constraint at runtime, use one of the `refine...` extension methods.
            |
-           |${MAGENTA}Inlined input$RESET: ${input.show}
-           |${MAGENTA}Inlined condition$RESET: ${cond.show}
+           |${MAGENTA}Inlined input$RESET: ${input.asTerm.show}
+           |${MAGENTA}Inlined condition$RESET: ${cond.asTerm.show}
            |${MAGENTA}Message$RESET: $messageValue
-           |${MAGENTA}Reason$RESET: $err""".stripMargin
+           |${MAGENTA}Reason$RESET: ${err.prettyPrint()}""".stripMargin
       ),
       identity
     )
@@ -42,7 +45,7 @@ private def assertConditionImpl[A: Type](input: Expr[A], cond: Expr[Boolean], me
   if !condValue then
     compileTimeError(s"""|Could not satisfy a constraint for type $MAGENTA${inputType.show}$RESET.
                          |
-                         |${MAGENTA}Value$RESET: ${input.show}
+                         |${MAGENTA}Value$RESET: ${input.asTerm.show}
                          |${MAGENTA}Message$RESET: $messageValue""".stripMargin)
   '{}
 


### PR DESCRIPTION
Enhance error messages and support some other cases at compile time.

Partly closes #238. Other cases are not doable because Scala cancel any folding/inlining for them.