### PR TITLE
Fix incorrect object name in docs

### DIFF
--- a/docs/_docs/reference/newtypes.md
+++ b/docs/_docs/reference/newtypes.md
@@ -177,7 +177,7 @@ opaque type Temperature = Double :| Positive
 object Temperature extends RefinedTypeOps[Double, Positive, Temperature]
 
 opaque type Moisture = Double :| Positive
-object Temperature extends RefinedTypeOps[Double, Positive, Moisture]
+object Moisture extends RefinedTypeOps[Double, Positive, Moisture]
 ```
 
 ```scala


### PR DESCRIPTION
just a small fix to one of the examples 