### PR TITLE
docs: Add links to videos and articles to the website

### DIFF
--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -21,3 +21,4 @@ This website contains documentation and tutorial to take Iron in hand.
 
 - [[API docs|io.github.iltotore.iron]]
 - [References](reference/index.md)
+- [Talks and articles](talks-and-articles.md)

--- a/docs/_docs/talks-and-articles.md
+++ b/docs/_docs/talks-and-articles.md
@@ -1,0 +1,21 @@
+---
+title: "Talks and articles"
+---
+
+# Talks and articles
+
+## Talks/Videos
+
+- [How to write library docs | Iron review](https://www.youtube.com/watch?v=4pq1elOap9k) by [@Zelenya](https://github.com/Zelenya)
+- Armored type safety with Iron by [@rlemaitre](https://github.com/rlemaitre) and [@vbergeron](https://github.com/vbergeron) (chronological order):
+  - [Scala Matters 2023 edition](https://www.youtube.com/watch?v=lrdBoYSKSnw)
+  - [Scala.IO Nantes 2024 edition](https://www.youtube.com/watch?v=I3BvpzFVBto)
+  - [Scalar edition](https://www.youtube.com/watch?v=ZVQ72Zh4wjg)
+  - [ScalaMatsuri edition](https://www.youtube.com/watch?v=SrocjO2_2_w)
+- 🇫🇷 [[Sunny Tech 2024] Codez sans crainte: Scala 3 et Iron, les Héros de la Fiabilité en Prog Fonctionnel](https://www.youtube.com/watch?v=TGkZ2P8aVA4)
+  by [@rlemaitre](https://github.com/rlemaitre) and [@vbergeron](https://github.com/vbergeron) (again)
+
+## Articles
+
+- [What makes library docs great [Library review: Iron]](https://dev.to/zelenya/what-makes-library-docs-great-library-review-iron-518a) by [@Zelenya](https://github.com/Zelenya) (written version of the video mentioned above)
+- [Type safety with Iron](https://blog.michal.pawlik.dev/posts/scala/iron/) by [@majk-p](https://github.com/majk-p)

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -5,6 +5,7 @@ subsection:
   - page: code-of-conduct.md
   - page: contributing.md
   - page: comparison-refined.md
+  - page: talks-and-articles.md
   - title: "Reference"
     directory: reference
     index: reference/index.md


### PR DESCRIPTION
Add links to videos and articles to the website. Closes #255 