### PR TITLE
fix: DescribedAs Implication ambiguity

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -7,9 +7,9 @@ import mill._, define._, api.Result
 import scalalib._, scalalib.scalafmt._, scalalib.publish._, scalajslib._, scalanativelib._
 
 object versions {
-  val scala = "3.6.3"
+  val scala = "3.6.4"
   val scalaJS = "1.16.0"
-  val scalaNative = "0.5.6"
+  val scalaNative = "0.5.7"
 }
 
 trait BaseModule extends ScalaModule with ScalafmtModule with CiReleaseModule { outer =>

--- a/main/src/io/github/iltotore/iron/constraint/any.scala
+++ b/main/src/io/github/iltotore/iron/constraint/any.scala
@@ -123,12 +123,12 @@ object any:
     /**
      * A described constraint C1 implies C1.
      */
-    given [C1, C2, V <: String](using C1 ==> C2): (DescribedAs[C1, V] ==> C2) = Implication()
+    given [C1, C2, V <: String](using c1c2: C1 ==> C2, not: NotGiven[C1 ==> DescribedAs[C2, V]]): (DescribedAs[C1, V] ==> C2) = Implication()
 
     /**
      * A constraint C1 implies its "described" form.
      */
-    given [C1, C2, V <: String](using C1 ==> C2): (C1 ==> DescribedAs[C2, V]) = Implication()
+    given [C1, C2, V <: String](using c1c2: C1 ==> C2, not: NotGiven[DescribedAs[C1, V] ==> C2]): (C1 ==> DescribedAs[C2, V]) = Implication()
 
   object Not:
     class NotConstraint[A, C, Impl <: Constraint[A, C]](using Impl) extends Constraint[A, Not[C]]:

--- a/main/test/src/io/github/iltotore/iron/testing/AnySuite.scala
+++ b/main/test/src/io/github/iltotore/iron/testing/AnySuite.scala
@@ -15,6 +15,10 @@ object AnySuite extends TestSuite:
       test - Dummy.assertRefine[DescribedAs[True, "test"]]
       test - Dummy.assertNotRefine[DescribedAs[False, "test"]]
 
+    test("describedAs implications"):
+      val isTrue: Boolean :| DescribedAs[True, "test"] = true
+      val notFalse: Boolean :| DescribedAs[Not[False], "test"] = isTrue
+
     test("not"):
       test - Dummy.assertRefine[Not[False]]
       test - Dummy.assertNotRefine[Not[True]]


### PR DESCRIPTION
After 3.6.4 `Implication` from one `DescribedAs` to another has become ambiguous
```
    |Note that implicit conversions cannot be applied because they are ambiguous;    
    |                                             
    |both given instance given_==>_DescribedAs_C2 in object DescribedAs and
    |given instance given_==>_C1_DescribedAs in object DescribedAs match type 
    |
    |io.github.iltotore.iron.Implication[
    |  io.github.iltotore.iron.constraint.any.DescribedAs[
    |    io.github.iltotore.iron.True, ("test" : String)],
    |  io.github.iltotore.iron.constraint.any.DescribedAs[
    |    io.github.iltotore.iron.constraint.any.Not[io.github.iltotore.iron.False],
    |    ("test" : String)]
    |]
```


fixes #311 