### PR TITLE
fix: Wrong signature for RefinedType extractor

### DIFF
--- a/main/src/io/github/iltotore/iron/RefinedType.scala
+++ b/main/src/io/github/iltotore/iron/RefinedType.scala
@@ -118,7 +118,7 @@ trait RefinedType[A, C](using private val _rtc: RuntimeConstraint[A, C]):
           case None        => break(None)
       ))
 
-  def unapply(value: T): Option[A :| C] = Some(value.asInstanceOf[A :| C])
+  def unapply(value: A): Option[T] = option(value)
 
   inline given RefinedType.Mirror[T] with
     override type BaseType = A


### PR DESCRIPTION
Closes #321 

Example:

```scala
def extract(str: String): Option[NonBlank] = str match
  case s"--${NonBlank(str)}--" => Some(str)
  case _ => None

println(extract("----"))
println(extract("-- --"))
println(extract("--bonjour--"))
```

```scala
None
None
Some(bonjour)
```