### PR TITLE
Update documentation on `skunk` module and add `ValidEmail` constraint

### DIFF
--- a/docs/_docs/modules/skunk.md
+++ b/docs/_docs/modules/skunk.md
@@ -38,7 +38,7 @@ ivy"org.tpolecat::skunk-core::1.0.0-M10"
 
 Iron provides `Codec` instances for refined types:
 
-```scala 
+```scala 3
 import skunk.*
 import skunk.implicits.*
 import skunk.codec.all.*
@@ -53,11 +53,11 @@ type Username = String :| Not[Blank]
 val a: Query[Void, Username] = sql"SELECT name FROM users".query(varchar.refined)
 
 // defining a codec for a refined opaque type
-opaque type PositiveInt = Int :| Positive
-object PositiveInt extends RefinedTypeOps[Int, Positive, PositiveInt]:
-  given codec: Codec[PositiveInt] = int4.refined[Positive]
+type PositiveInt = PositiveInt.T
+object PositiveInt extends RefinedType[Int, Positive]:
+  given codec: Codec[PositiveInt] = int4.refined[Positive].imap(assume)(_.value)
 
 // defining a codec for a refined case class
-final case class User(name: Username, age: Int :| Positive)
+final case class User(name: Username, age: PositiveInt)
 given Codec[User] = (varchar.refined[Not[Blank]] *: PositiveInt.codec).to[User]
 ```

--- a/main/src/io/github/iltotore/iron/constraint/string.scala
+++ b/main/src/io/github/iltotore/iron/constraint/string.scala
@@ -85,6 +85,14 @@ object string:
     Match["^([0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12})"],
     "Should be an UUID"
   ]
+  
+  /**
+   * Tests if the input is a valid email address.
+   */
+  type ValidEmail = DescribedAs[
+    Match["^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"],
+    "Should be an email"
+  ]
 
   /**
    * Tests if the input is a valid semantic version as defined in [semver site](https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string).


### PR DESCRIPTION
This PR basically was intended to update the `skunk` module documentation, as the previous one used the deprecated `RefinedTypeOps` newtype generator. 

However, since the PR was going to be so small, I also wanted to include a `ValidEmail` constraint under the `constraints.string` package, since there are already constraints for UUIDs and URLs. I tried my best to create the email regex, but I don't know if it meets Iron's standards. I'm happy to change it if it doesn't!

That's pretty much it, have a nice one! 💖